### PR TITLE
various improvements for cross-platform development

### DIFF
--- a/cpp/unreal_plugins/CoreUtils/Source/Config.cpp
+++ b/cpp/unreal_plugins/CoreUtils/Source/Config.cpp
@@ -24,10 +24,9 @@ void Config::initialize()
         // Read config file contents into a YAML::Node
         config_file = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir().Append("Temp/config.yaml"));
         config_ = YAML::LoadFile(TCHAR_TO_UTF8(*config_file));
-    }
 
     // Otherwise assert
-    else {
+    } else {
         ASSERT(false);
     }
 }

--- a/cpp/unreal_plugins/CoreUtils/Source/CoreUtils.Build.cs
+++ b/cpp/unreal_plugins/CoreUtils/Source/CoreUtils.Build.cs
@@ -32,11 +32,11 @@ public class CoreUtils : ModuleRules
 
         if (Target.Platform == UnrealTargetPlatform.Win64) {
             PublicDefinitions.Add("YAML_CPP_STATIC_DEFINE");
-            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "ThirdParty", "yaml-cpp", "build", "Release", "yaml-cpp.lib"));
+            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "ThirdParty", "yaml-cpp", "BUILD", "Win64", "Release", "yaml-cpp.lib"));
         } else if (Target.Platform == UnrealTargetPlatform.Mac) {
-            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "ThirdParty", "yaml-cpp", "build", "libyaml-cpp.a"));
+            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "ThirdParty", "yaml-cpp", "BUILD", "Mac", "libyaml-cpp.a"));
         } else if (Target.Platform == UnrealTargetPlatform.Linux) {
-            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "ThirdParty", "yaml-cpp", "build", "libyaml-cpp.a"));
+            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "ThirdParty", "yaml-cpp", "BUILD", "Linux", "libyaml-cpp.a"));
         } else {
             throw new Exception("Unexpected: Target.Platform == " + Target.Platform);
         }

--- a/cpp/unreal_plugins/OpenBot/Source/OpenBot.Build.cs
+++ b/cpp/unreal_plugins/OpenBot/Source/OpenBot.Build.cs
@@ -2,6 +2,7 @@
 // Copyright(c) 2022 Intel. Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 //
 
+using System;
 using System.IO;
 using UnrealBuildTool;
 
@@ -27,6 +28,14 @@ public class OpenBot : ModuleRules
         // Eigen
         //
 
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "ThirdParty", "libeigen"));
+        if (Target.Platform == UnrealTargetPlatform.Win64) {
+            PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "ThirdParty", "libeigen", "BUILD", "Win64", "include", "eigen3"));
+        } else if (Target.Platform == UnrealTargetPlatform.Mac) {
+            PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "ThirdParty", "libeigen", "BUILD", "Mac", "include", "eigen3"));
+        } else if (Target.Platform == UnrealTargetPlatform.Linux) {
+            PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "ThirdParty", "libeigen", "BUILD", "Linux", "include", "eigen3"));
+        } else {
+            throw new Exception("Unexpected: Target.Platform == " + Target.Platform);
+        }
     }
 }

--- a/cpp/unreal_plugins/OpenBot/Source/OpenBotPawn.cpp
+++ b/cpp/unreal_plugins/OpenBot/Source/OpenBotPawn.cpp
@@ -193,6 +193,7 @@ Eigen::Vector4f AOpenBotPawn::getDutyCycle() const
     return duty_cycle_;
 }
 
+BEGIN_IGNORE_COMPILER_WARNINGS
 Eigen::Vector4f AOpenBotPawn::getWheelRotationSpeeds() const
 {
     Eigen::Vector4f wheel_rotation_speeds;
@@ -202,6 +203,7 @@ Eigen::Vector4f AOpenBotPawn::getWheelRotationSpeeds() const
     wheel_rotation_speeds(3) = vehicle_movement_component_->PVehicle->mWheelsDynData.getWheelRotationSpeed(3); // Expressed in [RPM]
     return rpmToRadSec(wheel_rotation_speeds); // Expressed in [rad/s]
 }
+END_IGNORE_COMPILER_WARNINGS
 
 BEGIN_IGNORE_COMPILER_WARNINGS
 void AOpenBotPawn::resetPhysicsState()

--- a/cpp/unreal_plugins/SimulationController/Source/Box.h
+++ b/cpp/unreal_plugins/SimulationController/Source/Box.h
@@ -8,8 +8,7 @@
 
 #include "Rpclib.h"
 
-// Supported types for sending observation and action data types via msgpackrpc
-// enum values must match the values in code/python_package/spear/env.py
+// enum values must match python/spear/env.py
 enum class DataType : uint8_t
 {
     Boolean    = 0,

--- a/cpp/unreal_plugins/SimulationController/Source/SimulationController.Build.cs
+++ b/cpp/unreal_plugins/SimulationController/Source/SimulationController.Build.cs
@@ -38,11 +38,11 @@ public class SimulationController : ModuleRules
         PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "ThirdParty", "rpclib", "include"));
 
         if (Target.Platform == UnrealTargetPlatform.Win64) {
-            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "ThirdParty", "rpclib", "build", "Release", "rpc.lib"));
+            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "ThirdParty", "rpclib", "BUILD", "Win64", "Release", "rpc.lib"));
         } else if (Target.Platform == UnrealTargetPlatform.Mac) {
-            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "ThirdParty", "rpclib", "build", "librpc.a"));
+            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "ThirdParty", "rpclib", "BUILD", "Mac", "librpc.a"));
         } else if (Target.Platform == UnrealTargetPlatform.Linux) {
-            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "ThirdParty", "rpclib", "build", "librpc.a"));
+            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "ThirdParty", "rpclib", "BUILD", "Linux", "librpc.a"));
         } else {
             throw new Exception("Target.Platform == " + Target.Platform);
         }

--- a/docs/building_spearsim.md
+++ b/docs/building_spearsim.md
@@ -40,7 +40,7 @@ Our `SpearSim` project assumes that all of its required parameters are declared 
 
 ```console
 cd tools
-python generate_config.py
+python generate_config.py --unreal_project_dir path/to/spear/cpp/unreal_projects/SpearSim
 ```
 
 ## Build the `SpearSim` executable

--- a/docs/building_spearsim.md
+++ b/docs/building_spearsim.md
@@ -40,7 +40,7 @@ Our `SpearSim` project assumes that all of its required parameters are declared 
 
 ```console
 cd tools
-python generate_config.py --unreal_project_dir path/to/spear/cpp/unreal_projects/SpearSim
+python generate_config.py
 ```
 
 ## Build the `SpearSim` executable

--- a/python/spear/__init__.py
+++ b/python/spear/__init__.py
@@ -6,3 +6,4 @@ __version__ = "0.1.0"
 
 from spear.config import get_config
 from spear.env import Env
+from spear.path import path_exists, remove_path

--- a/python/spear/env.py
+++ b/python/spear/env.py
@@ -9,32 +9,33 @@ import numpy as np
 import os
 import psutil
 from subprocess import Popen
+import spear
 import sys
 import time
 
 
-# Enum values should match Box.h in SimulationController plugin
+# enum values must match cpp/unreal_plugins/SimulationController/Box.h
 class DataType(Enum):
-    Boolean = 0
-    UInteger8 = 1
-    Integer8 = 2
+    Boolean    = 0
+    UInteger8  = 1
+    Integer8   = 2
     UInteger16 = 3
-    Integer16 = 4
+    Integer16  = 4
     UInteger32 = 5
-    Integer32 = 6
-    Float32 = 7
-    Double = 8
+    Integer32  = 6
+    Float32    = 7
+    Double     = 8
 
 DATA_TYPE_TO_NUMPY_DTYPE = {
-    DataType.Boolean.value: np.dtype("?").type,
-    DataType.UInteger8.value: np.dtype("u1").type,
-    DataType.Integer8.value: np.dtype("i1").type,
+    DataType.Boolean.value:    np.dtype("?").type,
+    DataType.UInteger8.value:  np.dtype("u1").type,
+    DataType.Integer8.value:   np.dtype("i1").type,
     DataType.UInteger16.value: np.dtype("u2").type,
-    DataType.Integer16.value: np.dtype("i2").type,
+    DataType.Integer16.value:  np.dtype("i2").type,
     DataType.UInteger32.value: np.dtype("u4").type,
-    DataType.Integer32.value: np.dtype("i4").type,
-    DataType.Float32.value: np.dtype("f4").type,
-    DataType.Double.value: np.dtype("f8").type
+    DataType.Integer32.value:  np.dtype("i4").type,
+    DataType.Float32.value:    np.dtype("f4").type,
+    DataType.Double.value:     np.dtype("f8").type
 }
 
 
@@ -114,27 +115,25 @@ class Env(gym.Env):
 
     def close(self):
 
-        print("Closing Unreal instance...")
+        print("[SPEAR | env.py] Closing Unreal instance...")
         print()
 
-        # request to close Unreal instance
         self._close_unreal_instance()
         self._close_client_server_connection()
 
         try:
             status = self._process.status()
-        except psutil.NoSuchProcess: # On Windows OS, psutil.Process.status() throws psutil.NoSuchProcess exception if the process does not exist anymore.
+        except psutil.NoSuchProcess:
             pass
         else:
-            # do not return until Unreal application is closed
             while status in ["running", "sleeping", "disk-sleep"]:
                 time.sleep(1.0)
                 try:
                     status = self._process.status()
-                except psutil.NoSuchProcess: # On Windows OS, psutil.Process.status() throws psutil.NoSuchProcess exception if the process does not exist anymore.
+                except psutil.NoSuchProcess:
                     break
 
-        print("Finished closing Unreal instance.")
+        print("[SPEAR | env.py] Finished closing Unreal instance.")
         print()
 
     def _request_launch_unreal_instance(self):
@@ -142,61 +141,47 @@ class Env(gym.Env):
         if self._config.SPEAR.LAUNCH_MODE == "running_instance":
             return
 
-        launch_params = []
-
-        # Get launch executable from config
-        if self._config.SPEAR.LAUNCH_MODE == "uproject":
-            launch_executable = self._config.SPEAR.UNREAL_EDITOR_EXECUTABLE
-            launch_params.append(self._config.SPEAR.UPROJECT) # prepend uproject file to launch params
-        elif self._config.SPEAR.LAUNCH_MODE == "standalone_executable":
-            launch_executable = self._config.SPEAR.STANDALONE_EXECUTABLE
-        else:
-            assert False
-
-        # Read params required for launching the Unreal Engine executable:
-        launch_params.append("-game")
-        launch_params.append("-windowed")
-        launch_params.append("-novsync")
-        launch_params.append("-NoSound")
-        launch_params.append("-NoTextureStreaming")
-        launch_params.append("-resx={}".format(self._config.SPEAR.WINDOW_RESOLUTION_X))
-        launch_params.append("-resy={}".format(self._config.SPEAR.WINDOW_RESOLUTION_Y))
-        launch_params.append("-graphicsadapter={}".format(self._config.SPEAR.GPU_ID))
-
-        if self._config.SPEAR.RENDER_OFFSCREEN:
-            launch_params.append("-RenderOffscreen")
-
-        if len(self._config.SPEAR.UNREAL_INTERNAL_LOG_FILE) > 0:
-            launch_params.append("-log={}".format(self._config.SPEAR.UNREAL_INTERNAL_LOG_FILE))
-       
-        # Dump updated config params into a new yaml file
+        # write temp file
         temp_config_file = os.path.join(os.path.abspath(self._config.SPEAR.TEMP_DIR), "config.yaml")
 
-        # Unreal Engine server needs to read values from this config file
-        launch_params.append("-config_file={}".format(temp_config_file))
-
-        # Append any additional command-line arguments
-        for a in self._config.SPEAR.CUSTOM_COMMAND_LINE_ARGUMENTS:
-            launch_params.append("{}".format(a))
-
-        # On Windows, we need to pass in extra command-line parameters to enable DirectX 12 and so that calls to UE_Log and writes to std::cout are visible on the command-line.
-        if sys.platform == "win32":
-            launch_params.append("-dx12")            
-            launch_params.append("-stdout")
-            launch_params.append("-FullStdOutLogOutput")
-
-        # Provides additional control over which Vulkan devices are recognized by Unreal
-        if len(self._config.SPEAR.VULKAN_DEVICE_FILES) > 0:
-            print("Setting VK_ICD_FILENAMES environment variable: " + self._config.SPEAR.VULKAN_DEVICE_FILES)
-            os.environ["VK_ICD_FILENAMES"] = self._config.SPEAR.VULKAN_DEVICE_FILES
-
-        print("Writing temp config file: " + temp_config_file)
+        print("[SPEAR | env.py] Writing temp config file: " + temp_config_file)
         print()
 
         if not os.path.exists(os.path.abspath(self._config.SPEAR.TEMP_DIR)):
             os.makedirs(os.path.abspath(self._config.SPEAR.TEMP_DIR))
         with open(temp_config_file, "w") as output:
             self._config.dump(stream=output, default_flow_style=False)
+
+        # create a symlink to SPEAR.DATA_DIR
+        if self._config.SPEAR.DATA_DIR != "":
+
+            paks_dir = os.path.join(self._config.SPEAR.CONTENT_DIR, "Paks")
+            assert os.path.exists(paks_dir)
+            spear_data_dir = os.path.join(paks_dir, "SpearData")
+
+            if spear.path_exists(spear_data_dir):
+                print(f"[SPEAR | env.py] File or directory or symlink exists, removing: {spear_data_dir}")
+                spear.remove_path(spear_data_dir)
+
+            print(f"[SPEAR | env.py] Creating symlink: {spear_data_dir} -> {self._config.SPEAR.DATA_DIR}")
+            print()
+            os.symlink(self._config.SPEAR.DATA_DIR, spear_data_dir)
+
+        # provide additional control over which Vulkan devices are recognized by Unreal
+        if len(self._config.SPEAR.VULKAN_DEVICE_FILES) > 0:
+            print("[SPEAR | env.py] Setting VK_ICD_FILENAMES environment variable: " + self._config.SPEAR.VULKAN_DEVICE_FILES)
+            os.environ["VK_ICD_FILENAMES"] = self._config.SPEAR.VULKAN_DEVICE_FILES
+
+        # set up launch executable and command-line arguments
+        launch_args = []
+
+        if self._config.SPEAR.LAUNCH_MODE == "uproject":
+            launch_executable = self._config.SPEAR.UNREAL_EDITOR_EXECUTABLE
+            launch_args.append(self._config.SPEAR.UPROJECT)
+        elif self._config.SPEAR.LAUNCH_MODE == "standalone_executable":
+            launch_executable = self._config.SPEAR.STANDALONE_EXECUTABLE
+        else:
+            assert False
 
         assert os.path.exists(launch_executable)
 
@@ -218,62 +203,61 @@ class Env(gym.Env):
 
         assert os.path.exists(launch_executable_internal)
 
-        # create a symlink to SPEAR.DATA_DIR if one doesn't already exist
-        if self._config.SPEAR.DATA_DIR != "":
-            assert self._config.SPEAR.CONTENT_DIR != ""
-            paks_dir = os.path.join(self._config.SPEAR.CONTENT_DIR, "Paks")
-            assert os.path.exists(paks_dir)
-            data_dir = os.path.join(paks_dir, "Data")
+        launch_args.append("-game")
+        launch_args.append("-windowed")
+        launch_args.append("-novsync")
+        launch_args.append("-NoSound")
+        launch_args.append("-NoTextureStreaming")
+        launch_args.append("-resx={}".format(self._config.SPEAR.WINDOW_RESOLUTION_X))
+        launch_args.append("-resy={}".format(self._config.SPEAR.WINDOW_RESOLUTION_Y))
+        launch_args.append("-graphicsadapter={}".format(self._config.SPEAR.GPU_ID))
 
-            # if data_dir exists, it must be a symbolic link
-            if os.path.exists(data_dir):
-                assert os.path.islink(data_dir)
+        launch_args.append("-config_file={}".format(temp_config_file))
 
-            # if data_dir is a symbolic link that doesn't point to DATA_DIR, then unlink it
-            if os.path.islink(data_dir) and os.readlink(data_dir) != self._config.SPEAR.DATA_DIR:
-                print(f"Link target for {data_dir} is {os.readlink(data_dir)}, which doesn't match {self._config.SPEAR.DATA_DIR}, unlinking...")
-                print()
-                os.unlink(data_dir)
+        if self._config.SPEAR.RENDER_OFFSCREEN:
+            launch_args.append("-RenderOffscreen")
 
-            # if data_dir is not a symbolic link at this point, then link it to DATA_DIR
-            if not os.path.islink(data_dir):
-                print(f"Creating symlink: {data_dir} -> {self._config.SPEAR.DATA_DIR}")
-                print()
-                try:
-                    os.symlink(self._config.SPEAR.DATA_DIR, data_dir)
-                except OSError as e:
-                    print(e)
-                    print("\n\n\nThe config value SPEAR.DATA_DIR is set to a specific directory, so spear.Env() is trying to create a symlink. If you are on Windows, you need admin privileges.\n\n")
-                    assert False
+        if len(self._config.SPEAR.UNREAL_INTERNAL_LOG_FILE) > 0:
+            launch_args.append("-log={}".format(self._config.SPEAR.UNREAL_INTERNAL_LOG_FILE))
+       
+        # on Windows, we need to pass in extra command-line parameters to enable DirectX 12
+        # and so that calls to UE_Log and writes to std::cout are visible on the command-line
+        if sys.platform == "win32":
+            launch_args.append("-dx12")            
+            launch_args.append("-stdout")
+            launch_args.append("-FullStdOutLogOutput")
 
-        args = [launch_executable_internal] + launch_params
+        for a in self._config.SPEAR.CUSTOM_COMMAND_LINE_ARGUMENTS:
+            launch_args.append("{}".format(a))
 
-        print("Launching executable with the following arguments:")
-        print(" ".join(args))
+        cmd = [launch_executable_internal] + launch_args
+
+        print("[SPEAR | env.py] Launching executable with the following command-line arguments:")
+        print(" ".join(cmd))
         print()
 
-        print("Launching executable with the following config values:")
+        print("[SPEAR | env.py] Launching executable with the following config values:")
         print(self._config)
         print()
         
-        popen = Popen(args)
+        popen = Popen(cmd)
         self._process = psutil.Process(popen.pid)
 
-        # See https://github.com/giampaolo/psutil/blob/master/psutil/_common.py for possible status values
+        # see https://github.com/giampaolo/psutil/blob/master/psutil/_common.py for possible status values
         status = self._process.status()
         if status not in ["running", "sleeping", "disk-sleep"]:
-            print("ERROR: Unrecognized process status: " + status)
-            print("ERROR: Killing process " + str(self._process.pid) + "...")
+            print("[SPEAR | env.py] ERROR: Unrecognized process status: " + status)
+            print("[SPEAR | env.py] ERROR: Killing process " + str(self._process.pid) + "...")
             self._force_kill_unreal_instance()
             self._close_client_server_connection()
             assert False
 
     def _connect_to_unreal_instance(self):
 
-        print(f"Connecting to Unreal application...")
+        print(f"[SPEAR | env.py] Connecting to Unreal application...")
         print()
         
-        # If we're connecting to a running instance, then we assume that the RPC server is already running and only try to connect once
+        # if we're connecting to a running instance, then we assume that the RPC server is already running and only try to connect once
         if self._config.SPEAR.LAUNCH_MODE == "running_instance":
             connected = False
             try:
@@ -288,7 +272,7 @@ class Env(gym.Env):
                 # See https://github.com/msgpack-rpc/msgpack-rpc-python/issues/14
                 self._close_client_server_connection()
 
-        # Otherwise try to connect repeatedly, since the RPC server might not have started yet
+        # otherwise try to connect repeatedly, since the RPC server might not have started yet
         else:
             connected = False
             start_time_seconds = time.time()
@@ -297,8 +281,8 @@ class Env(gym.Env):
                 # See https://github.com/giampaolo/psutil/blob/master/psutil/_common.py for possible status values
                 status = self._process.status()
                 if status not in ["running", "sleeping", "disk-sleep"]:
-                    print("ERROR: Unrecognized process status: " + status)
-                    print("ERROR: Killing process " + str(self._process.pid) + "...")
+                    print("[SPEAR | env.py] ERROR: Unrecognized process status: " + status)
+                    print("[SPEAR | env.py] ERROR: Killing process " + str(self._process.pid) + "...")
                     self._force_kill_unreal_instance()
                     self._close_client_server_connection()
                     assert False
@@ -318,7 +302,7 @@ class Env(gym.Env):
 
         if not connected:
             if self._config.SPEAR.LAUNCH_MODE != "running_instance":
-                print("ERROR: Couldn't connect, killing process " + str(self._process.pid) + "...")
+                print("[SPEAR | env.py] ERROR: Couldn't connect, killing process " + str(self._process.pid) + "...")
                 self._force_kill_unreal_instance()
                 self._close_client_server_connection()
             assert False
@@ -327,7 +311,8 @@ class Env(gym.Env):
             time.sleep(self._config.SPEAR.RPC_CLIENT_AFTER_INITIALIZE_CONNECTION_SLEEP_TIME_SECONDS)
 
     def _initialize_unreal_instance(self):
-        # do one tick cyle here to prep Unreal Engine so that we can receive valid observations
+        # Do one complete tick to guarantee that we can receive valid observations. If we don't do
+        # this, it is possible that Unreal will return an initial visual observation of all zeros.
         self._begin_tick()
         self._tick()
         self._end_tick()
@@ -373,11 +358,9 @@ class Env(gym.Env):
         return_dict = {}
         for name, component in data.items():
             
-            # get shape and dtype of the data component
             shape = space.spaces[name].shape
             dtype = space.spaces[name].dtype
 
-            # change byte order based on Unreal instance and client endianness
             if self._byte_order is not None:
                 dtype = dtype.newbyteorder(self._byte_order)
 
@@ -453,7 +436,8 @@ class Env(gym.Env):
                  "agent_step_info": self._deserialize(agent_step_info, self._agent_step_info_space) }
 
     def _reset(self):
-        # reset the Task first in case it needs to set the position of actors, then reset Agent so it can refine the position of actors
+        # reset the task first in case it needs to set the position of actors,
+        # then reset agent so it can refine the position of actors
         self._client.call("resetTask")
         self._client.call("resetAgent")
 

--- a/python/spear/path.py
+++ b/python/spear/path.py
@@ -1,0 +1,43 @@
+#
+# Copyright(c) 2022 Intel. Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+#
+
+import os
+import shutil
+import sys
+
+
+def path_exists(path):
+    if os.path.exists(path) or os.path.islink(path):
+        return True
+
+    head, tail = os.path.split(path)
+    if tail == "":
+        return os.path.exists(head)
+    else:
+        return tail in os.listdir(head)
+
+def remove_path(path):
+    if not path_exists(path):
+        return
+
+    if os.path.islink(path):
+        os.unlink(path)
+    elif os.path.isfile(path):
+        os.remove(path)
+    elif os.path.isdir(path):
+        shutil.rmtree(path, ignore_errors=True)
+    else:
+        # if we have a broken symlink, then try to use the command-line (we don't attempt to use
+        # subprocess.run() because it returns an error when attempting to remove broken symlinks
+        if sys.platform == "win32":
+            rm_cmd = "del"
+        elif sys.platform == "darwin":
+            rm_cmd = "rm"
+        elif sys.platform == "linux":
+            rm_cmd = "rm"
+        else:
+            assert False
+        cmd = f"{rm_cmd} {path}"
+        cmd_result = os.system(cmd)
+        assert cmd_result == 0

--- a/tools/build_third_party_libs.py
+++ b/tools/build_third_party_libs.py
@@ -9,155 +9,377 @@ import subprocess
 import sys
 
 
-TOOLS_DIR = os.path.dirname(os.path.realpath(__file__))
-MIN_CMAKE_VERSION = "3.5.1"
-
-
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--num_parallel_jobs", "-n", type=int, default=1)
-    parser.add_argument("--clang_cc_bin", "-ccb", default="clang")
-    parser.add_argument("--clang_cxx_bin", "-cxxb", default="clang++")
+    parser.add_argument("--num_parallel_jobs", type=int, default=1)
+    parser.add_argument("--c_compiler")
+    parser.add_argument("--cxx_compiler")
     args = parser.parse_args()
 
+
     #
-    # check minimum cmake version (required because we invoke cmake --build directly)
+    # define build variables
     #
 
-    min_cmake_version = MIN_CMAKE_VERSION.split(".")
-    print(f"The minimum cmake version required is {MIN_CMAKE_VERSION}, checking if this requirement is met...")
-    cmake_version = (subprocess.run(["cmake", "--version"], stdout=subprocess.PIPE).stdout).decode("utf-8").split('\n')[0].split(' ')[-1]
-    print(f"The cmake version on this sytem is {cmake_version}")
-    cmake_version = cmake_version.split(".")
-    assert len(min_cmake_version) == len(cmake_version)
-    for i in range(len(min_cmake_version)):
-        if int(cmake_version[i]) < int(min_cmake_version[i]):
+    tools_dir = os.path.dirname(os.path.realpath(__file__))
+
+    if args.c_compiler is None:
+        if sys.platform == "win32":
+            c_compiler = "cl"
+        elif sys.platform == "darwin":
+            c_compiler = "clang"
+        elif sys.platform == "linux":
+            c_compiler = "clang"
+        else:
             assert False
-        elif int(cmake_version[i]) > int(min_cmake_version[i]):
-            break
-    print("The cmake version on this system meets our minimum requirements.")
+    else:
+        c_compiler = args.c_compiler
+
+    if args.cxx_compiler is None:
+        if sys.platform == "win32":
+            cxx_compiler = "cl"
+        elif sys.platform == "darwin":
+            cxx_compiler = "clang++"
+        elif sys.platform == "linux":
+            cxx_compiler = "clang++"
+        else:
+            assert False
+    else:
+        cxx_compiler = args.cxx_compiler
+
+    if sys.platform == "win32":
+        platform_dir = "Win64"
+    elif sys.platform == "darwin":
+        platform_dir = "Mac"
+    elif sys.platform == "linux":
+        platform_dir = "Linux"
+
+
+    #
+    # Eigen
+    #
+
+    print("[SPEAR | build_third_party_libs.py] Building Eigen...")
+
+    build_dir = os.path.realpath(os.path.join(tools_dir, "..", "third_party", "libeigen", "BUILD", platform_dir))
+
+    if os.path.isdir(build_dir):
+        print(f"[SPEAR | build_third_party_libs.py] Directory exists, removing: {build_dir}")
+        shutil.rmtree(build_dir, ignore_errors=True)
+
+    print(f"[SPEAR | build_third_party_libs.py] Creating directory and changing to working: {build_dir}")
+    os.makedirs(build_dir)
+    os.chdir(build_dir)
+
+    cmd = [
+        "cmake",
+        "-DCMAKE_C_COMPILER=" + c_compiler,
+        "-DCMAKE_CXX_COMPILER=" + cxx_compiler,
+        "-DCMAKE_INSTALL_PREFIX=" + build_dir,
+        os.path.join("..", "..")]
+    print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
+    cmd_result = subprocess.run(cmd)
+    assert cmd_result.returncode == 0
+
+    cmd = [
+        "cmake",
+        "--build",
+        ".",
+        "--target",
+        "install"]
+
+    print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
+    cmd_result = subprocess.run(cmd)
+    assert cmd_result.returncode == 0
+
+    print("[SPEAR | build_third_party_libs.py] Built Eigen successfully.")
     print()
 
-    if sys.platform == "linux":
-        os.environ["CC"] = args.clang_cc_bin
-        os.environ["CXX"] = args.clang_cxx_bin
 
     #
     # rbdl
     #
 
-    print("Building rbdl...")
-    build_dir = os.path.realpath(os.path.join(TOOLS_DIR, "..", "third_party", "rbdl", "build"))
+    print("[SPEAR | build_third_party_libs.py] Building rbdl...")
+
+    build_dir = os.path.realpath(os.path.join(tools_dir, "..", "third_party", "rbdl", "BUILD", platform_dir))
+    eigen3_include_dir = os.path.realpath(os.path.join(tools_dir, "..", "third_party", "libeigen", "BUILD", platform_dir, "include", "eigen3"))
+
     if os.path.isdir(build_dir):
+        print(f"[SPEAR | build_third_party_libs.py] Directory exists, removing: {build_dir}")
         shutil.rmtree(build_dir, ignore_errors=True)
 
+    print(f"[SPEAR | build_third_party_libs.py] Creating directory and changing to working: {build_dir}")
     os.makedirs(build_dir)
     os.chdir(build_dir)
 
-    if sys.platform == "linux":
-        cmake_args = ["cmake", "-DCMAKE_BUILD_TYPE=Release" , "-DRBDL_BUILD_STATIC=ON", "-DRBDL_BUILD_ADDON_URDFREADER=ON", "-DCMAKE_CXX_FLAGS='-stdlib=libc++'", "-DCMAKE_POSITION_INDEPENDENT_CODE=ON", ".."]
-        print(f"Executing cmd: {' '.join(cmake_args)}")
-        cmake_cmd = subprocess.run(cmake_args)
-        assert cmake_cmd.returncode == 0
-        cmake_args = ["cmake",  "--build", ".", "-j", "{0}".format(args.num_parallel_jobs)]
+    if sys.platform == "win32":
+
+        cmd = [
+            "cmake",
+            "-DCMAKE_C_COMPILER=" + c_compiler,
+            "-DCMAKE_CXX_COMPILER=" + cxx_compiler,
+            "-DCMAKE_BUILD_TYPE=Release" ,
+            "-DRBDL_BUILD_STATIC=ON",
+            "-DRBDL_BUILD_ADDON_URDFREADER=ON",
+            "-DCMAKE_CXX_FLAGS='/bigobj /DNOMINMAX'",
+            "-DEIGEN3_INCLUDE_DIR=" + eigen3_include_dir,
+            os.path.join("..", "..")]
+
+        print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
+        cmd_result = subprocess.run(cmd)
+        assert cmd_result.returncode == 0
+
+        cmd = [
+            "cmake",
+            "--build",
+            ".",
+            "--config",
+            "Release",
+            "-j",
+            f"{args.num_parallel_jobs}"]
+
     elif sys.platform == "darwin":
-        cmake_args = ["cmake", "-DCMAKE_BUILD_TYPE=Release" , "-DRBDL_BUILD_STATIC=ON", "-DRBDL_BUILD_ADDON_URDFREADER=ON", ".."]
-        print(f"Executing cmd: {' '.join(cmake_args)}")
-        cmake_cmd = subprocess.run(cmake_args)
-        assert cmake_cmd.returncode == 0
-        cmake_args = ["cmake",  "--build", ".", "-j", "{0}".format(args.num_parallel_jobs)]
-    elif sys.platform == "win32":
-        cmake_args = ["cmake", "-DCMAKE_BUILD_TYPE=Release" , "-DRBDL_BUILD_STATIC=ON", "-DRBDL_BUILD_ADDON_URDFREADER=ON",  "-DCMAKE_CXX_FLAGS='/bigobj /DNOMINMAX'", ".."]
-        print(f"Executing cmd: {' '.join(cmake_args)}")
-        cmake_cmd = subprocess.run(cmake_args)
-        assert cmake_cmd.returncode == 0
-        cmake_args = ["cmake",  "--build", ".", "--config", "Release", "-j", "{0}".format(args.num_parallel_jobs)]
+
+        cmd = [
+            "cmake",
+            "-DCMAKE_C_COMPILER=" + c_compiler,
+            "-DCMAKE_CXX_COMPILER=" + cxx_compiler,
+            "-DCMAKE_BUILD_TYPE=Release" ,
+            "-DRBDL_BUILD_STATIC=ON",
+            "-DRBDL_BUILD_ADDON_URDFREADER=ON",
+            "-DEIGEN3_INCLUDE_DIR=" + eigen3_include_dir,
+            os.path.join("..", "..")]
+
+        print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
+        cmd_result = subprocess.run(cmd)
+        assert cmd_result.returncode == 0
+
+        cmd = [
+            "cmake",
+            "--build",
+            ".",
+            "-j",
+            f"{args.num_parallel_jobs}"]
+
+    elif sys.platform == "linux":
+
+        cmd = [
+            "cmake",
+            "-DCMAKE_C_COMPILER=" + c_compiler,
+            "-DCMAKE_CXX_COMPILER=" + cxx_compiler,
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DRBDL_BUILD_STATIC=ON",
+            "-DRBDL_BUILD_ADDON_URDFREADER=ON",
+            "-DCMAKE_CXX_FLAGS='-stdlib=libc++'",
+            "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
+            "-DEIGEN3_INCLUDE_DIR=" + eigen3_include_dir,
+            os.path.join("..", "..")]
+
+        print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
+        cmd_result = subprocess.run(cmd)
+        assert cmd_result.returncode == 0
+
+        cmd = [
+            "cmake",
+            "--build",
+            ".",
+            "-j",
+            f"{args.num_parallel_jobs}"]
+
     else:
-        assert False, "This OS is not supported."
+        assert False
     
-    print(f"Executing cmd: {' '.join(cmake_args)}")
-    cmake_cmd = subprocess.run(cmake_args)
-    assert cmake_cmd.returncode == 0
-    print("Built rbdl successfully.")
+    print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
+    cmd_result = subprocess.run(cmd)
+    assert cmd_result.returncode == 0
+
+    print("[SPEAR | build_third_party_libs.py] Built rbdl successfully.")
     print()
+
 
     #
     # rpclib
     #
 
-    print("Building rpclib...")
-    build_dir = os.path.realpath(os.path.join(TOOLS_DIR, "..", "third_party", "rpclib", "build"))
+    print("[SPEAR | build_third_party_libs.py] Building rpclib...")
+
+    build_dir = os.path.realpath(os.path.join(tools_dir, "..", "third_party", "rpclib", "BUILD", platform_dir))
+
     if os.path.isdir(build_dir):
+        print(f"[SPEAR | build_third_party_libs.py] Directory exists, removing: {build_dir}")
         shutil.rmtree(build_dir, ignore_errors=True)
 
+    print(f"[SPEAR | build_third_party_libs.py] Creating directory and changing to working: {build_dir}")
     os.makedirs(build_dir)
     os.chdir(build_dir)
 
-    if sys.platform == "linux":
-        cmake_args = ["cmake", "-DCMAKE_BUILD_TYPE=Release" , "-DCMAKE_CXX_FLAGS='-stdlib=libc++'", "-DCMAKE_POSITION_INDEPENDENT_CODE=ON", ".."]
-        print(f"Executing cmd: {' '.join(cmake_args)}")
-        cmake_cmd = subprocess.run(cmake_args)
-        assert cmake_cmd.returncode == 0
-        cmake_args = ["cmake",  "--build", ".", "-j", "{0}".format(args.num_parallel_jobs)]
-    elif sys.platform == "darwin":
-        cmake_args = ["cmake", "-DCMAKE_BUILD_TYPE=Release", "-DCMAKE_CXX_FLAGS='-mmacosx-version-min=10.14'", ".."]
-        print(f"Executing cmd: {' '.join(cmake_args)}")
-        cmake_cmd = subprocess.run(cmake_args)
-        assert cmake_cmd.returncode == 0
-        cmake_args = ["cmake",  "--build", ".", "-j", "{0}".format(args.num_parallel_jobs)]
-    elif sys.platform == "win32":
-        cmake_args = ["cmake", "-DCMAKE_BUILD_TYPE=Release", ".."]
-        print(f"Executing cmd: {' '.join(cmake_args)}")
-        cmake_cmd = subprocess.run(cmake_args)
-        assert cmake_cmd.returncode == 0
-        cmake_args = ["cmake",  "--build", ".", "--config", "Release", "-j", "{0}".format(args.num_parallel_jobs)]
-    else:
-        assert False, "This OS is not supported."
+    if sys.platform == "win32":
 
-    print(f"Executing cmd: {' '.join(cmake_args)}")
-    cmake_cmd = subprocess.run(cmake_args)
-    assert cmake_cmd.returncode == 0
-    print("Built rpclib successfully.")
+        cmd = [
+            "cmake",
+            "-DCMAKE_C_COMPILER=" + c_compiler,
+            "-DCMAKE_CXX_COMPILER=" + cxx_compiler,
+            "-DCMAKE_BUILD_TYPE=Release",
+            os.path.join("..", "..")]
+
+        print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
+        cmd_result = subprocess.run(cmd)
+        assert cmd_result.returncode == 0
+
+        cmd = [
+            "cmake",
+            "--build",
+            ".",
+            "--config",
+            "Release",
+            "-j",
+            f"{args.num_parallel_jobs}"]
+
+    elif sys.platform == "darwin":
+
+        cmd = [
+            "cmake",
+            "-DCMAKE_C_COMPILER=" + c_compiler,
+            "-DCMAKE_CXX_COMPILER=" + cxx_compiler,
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DCMAKE_CXX_FLAGS='-mmacosx-version-min=10.14'",
+            os.path.join("..", "..")]
+
+        print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
+        cmd_result = subprocess.run(cmd)
+        assert cmd_result.returncode == 0
+
+        cmd = [
+            "cmake",
+            "--build",
+            ".",
+            "-j",
+            f"{args.num_parallel_jobs}"]
+
+    elif sys.platform == "linux":
+
+        cmd = [
+            "cmake",
+            "-DCMAKE_C_COMPILER=" + c_compiler,
+            "-DCMAKE_CXX_COMPILER=" + cxx_compiler,
+            "-DCMAKE_BUILD_TYPE=Release" ,
+            "-DCMAKE_CXX_FLAGS='-stdlib=libc++'",
+            "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
+            os.path.join("..", "..")]
+
+        print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
+        cmd_result = subprocess.run(cmd)
+        assert cmd_result.returncode == 0
+
+        cmd = [
+            "cmake",
+            "--build",
+            ".",
+            "-j",
+            f"{args.num_parallel_jobs}"]
+
+    else:
+        assert False
+
+    print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
+    cmd_result = subprocess.run(cmd)
+    assert cmd_result.returncode == 0
+
+    print("[SPEAR | build_third_party_libs.py] Built rpclib successfully.")
     print()
+
 
     #
     # yamp-cpp
     #
 
-    print("Building yaml-cpp...")
-    build_dir = os.path.realpath(os.path.join(TOOLS_DIR, "..", "third_party", "yaml-cpp", "build"))
+    print("[SPEAR | build_third_party_libs.py] Building yaml-cpp...")
+    build_dir = os.path.realpath(os.path.join(tools_dir, "..", "third_party", "yaml-cpp", "BUILD", platform_dir))
+
     if os.path.isdir(build_dir):
+        print("[SPEAR | build_third_party_libs.py] Directory exists, removing: " + build_dir)
         shutil.rmtree(build_dir, ignore_errors=True)
 
+    print("[SPEAR | build_third_party_libs.py] Creating directory and changing to working: " + build_dir)
     os.makedirs(build_dir)
     os.chdir(build_dir)
 
-    if sys.platform == "linux":
-        cmake_args = ["cmake", "-DCMAKE_BUILD_TYPE=Release" , "-DCMAKE_CXX_FLAGS='-stdlib=libc++'", "-DCMAKE_POSITION_INDEPENDENT_CODE=ON", ".."]
-        print(f"Executing cmd: {' '.join(cmake_args)}")
-        cmake_cmd = subprocess.run(cmake_args)
-        assert cmake_cmd.returncode == 0
-        cmake_args = ["cmake",  "--build", ".", "-j", "{0}".format(args.num_parallel_jobs)]
+    if sys.platform == "win32":
+
+        cmd = [
+            "cmake",
+            "-DCMAKE_C_COMPILER=" + c_compiler,
+            "-DCMAKE_CXX_COMPILER=" + cxx_compiler,
+            "-DCMAKE_BUILD_TYPE=Release",
+            os.path.join("..", "..")]
+
+        print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
+        cmd_result = subprocess.run(cmd)
+        assert cmd_result.returncode == 0
+
+        cmd = [
+            "cmake",
+            "--build",
+            ".",
+            "--config",
+            "Release",
+            "-j",
+            "{0}".format(args.num_parallel_jobs)]
+
     elif sys.platform == "darwin":
-        cmake_args = ["cmake", "-DCMAKE_BUILD_TYPE=Release", "-DCMAKE_CXX_FLAGS='-mmacosx-version-min=10.14'", ".."]
-        print(f"Executing cmd: {' '.join(cmake_args)}")
-        cmake_cmd = subprocess.run(cmake_args)
-        assert cmake_cmd.returncode == 0
-        cmake_args = ["cmake",  "--build", ".", "-j", "{0}".format(args.num_parallel_jobs)]
-    elif sys.platform == "win32":
-        cmake_args = ["cmake", "-DCMAKE_BUILD_TYPE=Release", ".."]
-        print(f"Executing cmd: {' '.join(cmake_args)}")
-        cmake_cmd = subprocess.run(cmake_args)
-        assert cmake_cmd.returncode == 0
-        cmake_args = ["cmake",  "--build", ".", "--config", "Release", "-j", "{0}".format(args.num_parallel_jobs)]
+
+        cmd = [
+            "cmake",
+            "-DCMAKE_C_COMPILER=" + c_compiler,
+            "-DCMAKE_CXX_COMPILER=" + cxx_compiler,
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DCMAKE_CXX_FLAGS='-mmacosx-version-min=10.14'",
+            os.path.join("..", "..")]
+
+        print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
+        cmd_result = subprocess.run(cmd)
+        assert cmd_result.returncode == 0
+
+        cmd = [
+            "cmake",
+            "--build",
+            ".",
+            "-j",
+            f"{args.num_parallel_jobs}"]
+
+    elif sys.platform == "linux":
+
+        cmd = [
+            "cmake",
+            "-DCMAKE_C_COMPILER=" + c_compiler,
+            "-DCMAKE_CXX_COMPILER=" + cxx_compiler,
+            "-DCMAKE_BUILD_TYPE=Release" ,
+            "-DCMAKE_CXX_FLAGS='-stdlib=libc++'",
+            "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
+            os.path.join("..", "..")]
+
+        print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
+        cmd_result = subprocess.run(cmd)
+        assert cmd_result.returncode == 0
+
+        cmd = [
+            "cmake",
+            "--build",
+            ".",
+            "-j",
+            f"{args.num_parallel_jobs}"]
+
     else:
-        assert False, "This OS is not supported."
+        assert False
     
-    print(f"Executing cmd: {' '.join(cmake_args)}")
-    cmake_cmd = subprocess.run(cmake_args)
-    assert cmake_cmd.returncode == 0
-    print("Built yaml-cpp successfully.")
+    print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
+    cmd_result = subprocess.run(cmd)
+    assert cmd_result.returncode == 0
+
+    print("[SPEAR | build_third_party_libs.py] Built yaml-cpp successfully.")
     print()
 
-    print("Done.")
+
+    print("[SPEAR | build_third_party_libs.py] Done.")

--- a/tools/build_third_party_libs.py
+++ b/tools/build_third_party_libs.py
@@ -123,7 +123,7 @@ if __name__ == "__main__":
             "-DCMAKE_BUILD_TYPE=Release" ,
             "-DRBDL_BUILD_STATIC=ON",
             "-DRBDL_BUILD_ADDON_URDFREADER=ON",
-            "-DCMAKE_CXX_FLAGS='/bigobj /DNOMINMAX'",
+            "-DCMAKE_CXX_FLAGS='/bigobj /DNOMINMAX /EHs'",
             "-DEIGEN3_INCLUDE_DIR=" + eigen3_include_dir,
             os.path.join("..", "..")]
 
@@ -373,7 +373,7 @@ if __name__ == "__main__":
 
     else:
         assert False
-    
+
     print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
     cmd_result = subprocess.run(cmd)
     assert cmd_result.returncode == 0

--- a/tools/create_symbolic_links.py
+++ b/tools/create_symbolic_links.py
@@ -2,6 +2,7 @@
 # Copyright(c) 2022 Intel. Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 #
 
+import argparse
 import json
 import os
 import spear
@@ -9,23 +10,30 @@ import spear
 
 if __name__ == "__main__":
 
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--unreal_project_dir")
+    args = parser.parse_args()
+
     tools_dir           = os.path.dirname(os.path.realpath(__file__))
     unreal_projects_dir = os.path.realpath(os.path.join(tools_dir, "..", "cpp", "unreal_projects"))
     unreal_plugins_dir  = os.path.realpath(os.path.join(tools_dir, "..", "cpp", "unreal_plugins"))
     third_party_dir     = os.path.realpath(os.path.join(tools_dir, "..", "third_party"))
 
-    # get list of the projects and plugins we maintain
-    our_projects = os.listdir(unreal_projects_dir)
-    our_plugins = os.listdir(unreal_plugins_dir)
+    if args.unreal_project_dir:
+        unreal_project_dirs = [ os.path.realpath(args.unreal_project_dir) ]
+    else:
+        unreal_project_dirs = [ os.path.join(unreal_projects_dir, project) for project in os.listdir(unreal_projects_dir) ]
+
+    unreal_plugins = os.listdir(unreal_plugins_dir)
 
     # for each plugin...
-    for plugin in our_plugins:
+    for plugin in unreal_plugins:
 
         # ...if the plugin is a valid plugin (i.e., plugin dir has a uplugin file)
         uplugin = os.path.join(unreal_plugins_dir, plugin, plugin + ".uplugin")
         if os.path.exists(uplugin):
 
-            print(f"[SPEAR | create_sybmolic_links.py] Found plugin: {plugin}")
+            print(f"[SPEAR | create_sybmolic_links.py] Found uplugin: {uplugin}")
 
             # create a symlink to third_party
             symlink_third_party_dir = os.path.join(unreal_plugins_dir, plugin, "ThirdParty")
@@ -37,16 +45,17 @@ if __name__ == "__main__":
 
         print()
 
-    print()
-
     # for each project...
-    for project in our_projects:
+    for unreal_project_dir in unreal_project_dirs:
+
+        assert os.path.exists(unreal_project_dir)
 
         # ...if the project is a valid project (i.e., project dir has a uproject file)
-        uproject = os.path.join(unreal_projects_dir, project, project + ".uproject")
+        _, project = os.path.split(unreal_project_dir)
+        uproject = os.path.join(unreal_project_dir, project + ".uproject")
         if os.path.exists(uproject):
 
-            print(f"[SPEAR | create_sybmolic_links.py] Found project: {project}")
+            print(f"[SPEAR | create_sybmolic_links.py] Found uproject: {uproject}")
 
             # create a symlink to third_party
             symlink_third_party_dir = os.path.join(unreal_projects_dir, project, "ThirdParty")
@@ -57,29 +66,28 @@ if __name__ == "__main__":
             os.symlink(third_party_dir, symlink_third_party_dir)
 
             # get list of plugins from the uproject file
-            with open(os.path.join(unreal_projects_dir, project, project+'.uproject')) as f:
+            with open(os.path.join(unreal_projects_dir, project, project + ".uproject")) as f:
                 project_plugins = [ p["Name"] for p in json.load(f)["Plugins"] ]
             print(f"[SPEAR | create_sybmolic_links.py]     Plugin dependencies: {project_plugins}")
 
             # create a Plugins dir in the project dir
             project_plugins_dir = os.path.join(unreal_projects_dir, project, "Plugins")
-            if not os.path.exists(project_plugins_dir):
-                os.makedirs(project_plugins_dir)
+            os.makedirs(project_plugins_dir, exist_ok=True)
 
             # create symlink for each plugin listed in the project, if the plugin is in our unreal_plugins dir
             for project_plugin in project_plugins:
-                if project_plugin in our_plugins:
-                    our_plugin_dir = os.path.abspath(os.path.join(unreal_plugins_dir, project_plugin))
+                if project_plugin in unreal_plugins:
+                    plugin_dir = os.path.abspath(os.path.join(unreal_plugins_dir, project_plugin))
                     symlink_plugin_dir = os.path.abspath(os.path.join(project_plugins_dir, project_plugin))
                     if spear.path_exists(symlink_plugin_dir):
                         print(f"[SPEAR | create_sybmolic_links.py]         File or directory or symlink exists, removing: {symlink_plugin_dir}")
                         spear.remove_path(symlink_plugin_dir)
-                    print(f"[SPEAR | create_sybmolic_links.py]         Creating symlink: {symlink_plugin_dir} -> {our_plugin_dir}")
-                    os.symlink(our_plugin_dir, symlink_plugin_dir)
+                    print(f"[SPEAR | create_sybmolic_links.py]         Creating symlink: {symlink_plugin_dir} -> {plugin_dir}")
+                    os.symlink(plugin_dir, symlink_plugin_dir)
                 else:
                     print(f"[SPEAR | create_sybmolic_links.py]         {project} depends on {project_plugin}, but this plugin is not in {unreal_plugins_dir}, so we do not create a symlink...")
 
         print()
 
-    print()
     print("[SPEAR | create_sybmolic_links.py] Done.")
+ 

--- a/tools/create_symbolic_links.py
+++ b/tools/create_symbolic_links.py
@@ -4,86 +4,82 @@
 
 import json
 import os
-
-
-TOOLS_DIR           = os.path.dirname(os.path.realpath(__file__))
-UNREAL_PROJECTS_DIR = os.path.realpath(os.path.join(TOOLS_DIR, "..", "cpp", "unreal_projects"))
-UNREAL_PLUGINS_DIR  = os.path.realpath(os.path.join(TOOLS_DIR, "..", "cpp", "unreal_plugins"))
-THIRD_PARTY_DIR     = os.path.realpath(os.path.join(TOOLS_DIR, "..", "third_party"))
-
-
-def create_symlink(src, dst):
-    try:
-        os.symlink(src, dst)
-    except OSError as e:
-        print(e)
-        print("\n\n\nIf you are running this script on Windows, you need admin privileges.\n\n")
-        assert False
+import spear
 
 
 if __name__ == "__main__":
 
+    tools_dir           = os.path.dirname(os.path.realpath(__file__))
+    unreal_projects_dir = os.path.realpath(os.path.join(tools_dir, "..", "cpp", "unreal_projects"))
+    unreal_plugins_dir  = os.path.realpath(os.path.join(tools_dir, "..", "cpp", "unreal_plugins"))
+    third_party_dir     = os.path.realpath(os.path.join(tools_dir, "..", "third_party"))
+
     # get list of the projects and plugins we maintain
-    our_projects = os.listdir(UNREAL_PROJECTS_DIR)
-    our_plugins = os.listdir(UNREAL_PLUGINS_DIR)
+    our_projects = os.listdir(unreal_projects_dir)
+    our_plugins = os.listdir(unreal_plugins_dir)
 
     # for each plugin...
     for plugin in our_plugins:
 
         # ...if the plugin is a valid plugin (i.e., plugin dir has a uplugin file)
-        uplugin = os.path.join(UNREAL_PLUGINS_DIR, plugin, plugin+'.uplugin')
+        uplugin = os.path.join(unreal_plugins_dir, plugin, plugin + ".uplugin")
         if os.path.exists(uplugin):
 
-            print(f"Found plugin: {plugin}")
+            print(f"[SPEAR | create_sybmolic_links.py] Found plugin: {plugin}")
 
             # create a symlink to third_party
-            symlink_third_party_dir = os.path.join(UNREAL_PLUGINS_DIR, plugin, "ThirdParty")
-            if not os.path.exists(symlink_third_party_dir):
-                print(f"    Creating symlink: {symlink_third_party_dir} -> {THIRD_PARTY_DIR}")
-                create_symlink(THIRD_PARTY_DIR, symlink_third_party_dir)
-            else:
-                print(f"    {symlink_third_party_dir} already exists, so we do not create a symlink...")
+            symlink_third_party_dir = os.path.join(unreal_plugins_dir, plugin, "ThirdParty")
+            if spear.path_exists(symlink_third_party_dir):
+                print(f"[SPEAR | create_sybmolic_links.py]     File or directory or symlink exists, removing: {symlink_third_party_dir}")
+                spear.remove_path(symlink_third_party_dir)
+            print(f"[SPEAR | create_sybmolic_links.py]     Creating symlink: {symlink_third_party_dir} -> {third_party_dir}")
+            os.symlink(third_party_dir, symlink_third_party_dir)
+
+        print()
+
     print()
 
     # for each project...
     for project in our_projects:
 
         # ...if the project is a valid project (i.e., project dir has a uproject file)
-        uproject = os.path.join(UNREAL_PROJECTS_DIR, project, project+'.uproject')
+        uproject = os.path.join(unreal_projects_dir, project, project + ".uproject")
         if os.path.exists(uproject):
 
-            print(f"Found project: {project}")
+            print(f"[SPEAR | create_sybmolic_links.py] Found project: {project}")
 
             # create a symlink to third_party
-            symlink_third_party_dir = os.path.join(UNREAL_PROJECTS_DIR, project, "ThirdParty")
-            if not os.path.exists(symlink_third_party_dir):
-                print(f"    Creating symlink: {symlink_third_party_dir} -> {THIRD_PARTY_DIR}")
-                create_symlink(THIRD_PARTY_DIR, symlink_third_party_dir)
-            else:
-                print(f"    {symlink_third_party_dir} already exists, so we do not create a symlink...")
+            symlink_third_party_dir = os.path.join(unreal_projects_dir, project, "ThirdParty")
+            if spear.path_exists(symlink_third_party_dir):
+                print(f"[SPEAR | create_sybmolic_links.py]     File or directory or symlink exists, removing: {symlink_third_party_dir}")
+                spear.remove_path(symlink_third_party_dir)
+            print(f"[SPEAR | create_sybmolic_links.py]     Creating symlink: {symlink_third_party_dir} -> {third_party_dir}")
+            os.symlink(third_party_dir, symlink_third_party_dir)
 
             # get list of plugins from the uproject file
-            with open(os.path.join(UNREAL_PROJECTS_DIR, project, project+'.uproject')) as f:
+            with open(os.path.join(unreal_projects_dir, project, project+'.uproject')) as f:
                 project_plugins = [ p["Name"] for p in json.load(f)["Plugins"] ]
-            print(f"    Plugin dependencies: {project_plugins}")
+            print(f"[SPEAR | create_sybmolic_links.py]     Plugin dependencies: {project_plugins}")
 
             # create a Plugins dir in the project dir
-            project_plugins_dir = os.path.join(UNREAL_PROJECTS_DIR, project, "Plugins")
+            project_plugins_dir = os.path.join(unreal_projects_dir, project, "Plugins")
             if not os.path.exists(project_plugins_dir):
                 os.makedirs(project_plugins_dir)
 
             # create symlink for each plugin listed in the project, if the plugin is in our unreal_plugins dir
             for project_plugin in project_plugins:
                 if project_plugin in our_plugins:
-                    our_plugin_dir = os.path.abspath(os.path.join(UNREAL_PLUGINS_DIR, project_plugin))
+                    our_plugin_dir = os.path.abspath(os.path.join(unreal_plugins_dir, project_plugin))
                     symlink_plugin_dir = os.path.abspath(os.path.join(project_plugins_dir, project_plugin))
-                    if not os.path.exists(symlink_plugin_dir):
-                        print(f"        Creating symlink: {symlink_plugin_dir} -> {our_plugin_dir}")
-                        create_symlink(our_plugin_dir, symlink_plugin_dir)
-                    else:
-                        print(f"        {symlink_plugin_dir} already exists, so we do not create a symlink...")
+                    if spear.path_exists(symlink_plugin_dir):
+                        print(f"[SPEAR | create_sybmolic_links.py]         File or directory or symlink exists, removing: {symlink_plugin_dir}")
+                        spear.remove_path(symlink_plugin_dir)
+                    print(f"[SPEAR | create_sybmolic_links.py]         Creating symlink: {symlink_plugin_dir} -> {our_plugin_dir}")
+                    os.symlink(our_plugin_dir, symlink_plugin_dir)
                 else:
-                    print(f"        {project} depends on {project_plugin}, but this plugin is not in {UNREAL_PLUGINS_DIR}, so we do not create a symlink...")
-    print()
+                    print(f"[SPEAR | create_sybmolic_links.py]         {project} depends on {project_plugin}, but this plugin is not in {unreal_plugins_dir}, so we do not create a symlink...")
 
-    print("Done.")
+        print()
+
+    print()
+    print("[SPEAR | create_sybmolic_links.py] Done.")

--- a/tools/generate_config.py
+++ b/tools/generate_config.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     with open(output_config_file, "w") as output:
         config_node.dump(stream=output, default_flow_style=False)
 
-    print("Config file generated successfully: " + output_config_file)
+    print("[SPEAR | generate_config.py] Config file generated successfully: " + output_config_file)
     print()
 
-    print("Done.")
+    print("[SPEAR | generate_config.py] Done.")

--- a/tools/generate_config.py
+++ b/tools/generate_config.py
@@ -10,29 +10,48 @@ import spear
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
+    parser.add_argument("--unreal_project_dir")
     parser.add_argument("--user_config_files", nargs="*")
-    parser.add_argument("--unreal_project_dir", required=True)
     args = parser.parse_args()
 
-    # create a list of config files to be used
+    tools_dir           = os.path.dirname(os.path.realpath(__file__))
+    unreal_projects_dir = os.path.realpath(os.path.join(tools_dir, "..", "cpp", "unreal_projects"))
+
+    if args.unreal_project_dir:
+        unreal_project_dirs = [ os.path.realpath(args.unreal_project_dir) ]
+    else:
+        unreal_project_dirs = [ os.path.join(unreal_projects_dir, project) for project in os.listdir(unreal_projects_dir) ]
+
     if args.user_config_files:
         user_config_files = args.user_config_files
     else:
         user_config_files = []
-    
+
     # create a single CfgNode that contains data from all config files
     config_node = spear.get_config(user_config_files=user_config_files)
 
-    # dump updated config params into a new yaml file
-    output_temp_dir = os.path.realpath(os.path.join(args.unreal_project_dir, "Temp"))
-    if not os.path.exists(output_temp_dir):
-        os.makedirs(output_temp_dir)
+    # for each project...
+    for unreal_project_dir in unreal_project_dirs:
 
-    output_config_file = os.path.join(output_temp_dir, "config.yaml")
-    with open(output_config_file, "w") as output:
-        config_node.dump(stream=output, default_flow_style=False)
+        assert os.path.exists(unreal_project_dir)
 
-    print("[SPEAR | generate_config.py] Config file generated successfully: " + output_config_file)
-    print()
+        # ...if the project is a valid project (i.e., project dir has a uproject file)
+        _, project = os.path.split(unreal_project_dir)
+        uproject = os.path.join(unreal_project_dir, project + ".uproject")
+        if os.path.exists(uproject):
+
+            print(f"[SPEAR | generate_config.py] Found uproject: {uproject}")
+
+            # dump config params into a new yaml file
+            output_temp_dir = os.path.realpath(os.path.join(unreal_project_dir, "Temp"))
+            os.makedirs(output_temp_dir, exist_ok=True)
+
+            output_config_file = os.path.join(output_temp_dir, "config.yaml")
+            with open(output_config_file, "w") as output:
+                config_node.dump(stream=output, default_flow_style=False)
+
+            print("[SPEAR | generate_config.py] Generated config file: " + output_config_file)
+
+        print()
 
     print("[SPEAR | generate_config.py] Done.")


### PR DESCRIPTION
This PR includes the following improvements to support cross-platform development, i.e., where the source code lives in a common folder that is accessed by multiple operating systems:
- changed `build_third_party_libs.py` to:
  - place all build artifacts in a platform-specific top-level folder, so build artifacts for each platform can co-exist and don't interfere with each other
  - generate a well-behaved include folder for Eigen (the current code exports the entire top-level libeigen GitHub folder as an include folder, so you could `#include <README.md>` in C++ code and it wouldn't be a compilation error, which is undesirable behavior)
  - use the generated include folder for Eigen when building RBDL (the current code assumes that Eigen is already exported in a standard location that is findable by the `FindEigen3.cmake` file that is included in the RBDL repository, which defeats the purpose of including Eigen among our `third_party` dependencies)
  - fixed deprecation warnings on Windows
  - fixed exception warnings on Windows
- changed `generate_config.py` to iterate over all the projects in `unreal_projects`, instead of requiring the user to specify a project on the command-line, thereby making it easier to use and more consistent with other build tools
- added code that improves our handling of symlinks, especially symlinks that are created on one platform and accessed on another
- cleaned up and refactored code