### PR TITLE
add config flag to support non-config mode

### DIFF
--- a/cpp/unreal_plugins/CoreUtils/Source/CoreUtils/Config.cpp
+++ b/cpp/unreal_plugins/CoreUtils/Source/CoreUtils/Config.cpp
@@ -12,6 +12,7 @@
 #include "CoreUtils/Unreal.h"
 #include "CoreUtils/YamlCpp.h"
 
+bool Config::is_enabled_;
 YAML::Node Config::s_config_;
 
 void Config::initialize()
@@ -21,19 +22,26 @@ void Config::initialize()
     // If a config file is provided via the command-line, then load it
     if (FParse::Value(FCommandLine::Get(), TEXT("config_file="), config_file)) {
         s_config_ = YAML::LoadFile(Unreal::toStdString(config_file));
+        is_enabled_=true;
 
     // Otherwise, if MyProject/Temp/config.yaml exists, then load it
     } else if (FPaths::FileExists(FPaths::ConvertRelativePathToFull(FPaths::ProjectDir().Append("Temp/config.yaml")))) {
         config_file = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir().Append("Temp/config.yaml"));
         s_config_ = YAML::LoadFile(Unreal::toStdString(config_file));
+        is_enabled_=true;
 
     // Otherwise assert
     } else {
-        ASSERT(false);
+        is_enabled_ = false;
     }
 }
 
 void Config::terminate()
 {
     s_config_.reset();
+}
+
+bool Config::isEnabled()
+{
+    return is_enabled_;
 }

--- a/cpp/unreal_plugins/CoreUtils/Source/CoreUtils/Config.h
+++ b/cpp/unreal_plugins/CoreUtils/Source/CoreUtils/Config.h
@@ -17,6 +17,7 @@ class COREUTILS_API Config
 public:
     static void initialize();
     static void terminate();
+    static bool isEnabled();
 
     //
     // This function is used to extract a value from the Config system. This function takes as input
@@ -73,5 +74,6 @@ private:
     Config() = default;
     ~Config() = default;
 
+    static bool is_enabled_;
     static YAML::Node s_config_;
 };

--- a/cpp/unreal_plugins/CoreUtils/Source/CoreUtils/CoreUtils.cpp
+++ b/cpp/unreal_plugins/CoreUtils/Source/CoreUtils/CoreUtils.cpp
@@ -15,7 +15,7 @@ void CoreUtils::StartupModule()
     Config::initialize();
 
     // Wait for keyboard input, which is useful when attempting to attach a debugger to the running executable.
-    if (Config::get<bool>("CORE_UTILS.WAIT_FOR_KEYBOARD_INPUT_DURING_INITIALIZATION")) {
+    if (Config::isEnabled() && Config::get<bool>("CORE_UTILS.WAIT_FOR_KEYBOARD_INPUT_DURING_INITIALIZATION")) {
         std::cout << "[SPEAR | CoreUtils.cpp] Press ENTER to continue..." << std::endl;
         std::cin.get();
     }

--- a/cpp/unreal_plugins/OpenBot/Source/OpenBot/OpenBotPawn.cpp
+++ b/cpp/unreal_plugins/OpenBot/Source/OpenBot/OpenBotPawn.cpp
@@ -34,6 +34,10 @@ AOpenBotPawn::AOpenBotPawn(const FObjectInitializer& object_initializer) : APawn
 {
     std::cout << "[SPEAR | OpenBotPawn.cpp] AOpenBotPawn::AOpenBotPawn" << std::endl;
 
+    if (!Config::isEnabled()) {
+        return;
+    }
+
     ConstructorHelpers::FObjectFinder<USkeletalMesh> skeletal_mesh(*Unreal::toFString(Config::get<std::string>("OPENBOT.OPENBOT_PAWN.SKELETAL_MESH")));
     ASSERT(skeletal_mesh.Succeeded());
 

--- a/cpp/unreal_plugins/OpenBot/Source/OpenBot/OpenBotWheel.cpp
+++ b/cpp/unreal_plugins/OpenBot/Source/OpenBot/OpenBotWheel.cpp
@@ -16,6 +16,10 @@ UOpenBotWheel::UOpenBotWheel()
 {
     std::cout << "[SPEAR | OpenBotWheel.cpp] UOpenBotWheel::UOpenBotWheel" << std::endl;
 
+    if (!Config::isEnabled()) {
+        return;
+    }
+
     ConstructorHelpers::FObjectFinder<UStaticMesh> collision_mesh(TEXT("/Engine/EngineMeshes/Cylinder"));
     ASSERT(collision_mesh.Succeeded());
 

--- a/cpp/unreal_plugins/SimulationController/Source/SimulationController/SimulationController.cpp
+++ b/cpp/unreal_plugins/SimulationController/Source/SimulationController/SimulationController.cpp
@@ -90,7 +90,7 @@ void SimulationController::postWorldInitializationEventHandler(UWorld* world, co
 
     ASSERT(world);
 
-    if (world->IsGameWorld() && GEngine->GetWorldContextFromWorld(world)) {
+    if (Config::isEnabled() && world->IsGameWorld() && GEngine->GetWorldContextFromWorld(world)) {
         auto world_path_name = Config::get<std::string>("SIMULATION_CONTROLLER.WORLD_PATH_NAME");
         auto level_name = Config::get<std::string>("SIMULATION_CONTROLLER.LEVEL_NAME");
 

--- a/cpp/unreal_plugins/UrdfBot/Source/UrdfBot/UrdfBotPawn.cpp
+++ b/cpp/unreal_plugins/UrdfBot/Source/UrdfBot/UrdfBotPawn.cpp
@@ -21,6 +21,10 @@ AUrdfBotPawn::AUrdfBotPawn(const FObjectInitializer& object_initializer) : APawn
 {
     std::cout << "[SPEAR | UrdfBotPawn.cpp] AUrdfBotPawn::AUrdfBotPawn" << std::endl;
 
+    if (!Config::isEnabled()) {
+        return;
+    }
+
     // setup UUrdfRobotComponent
     UrdfRobotDesc robot_desc = UrdfParser::parse(Unreal::toStdString(FPaths::Combine(
         Unreal::toFString(Config::get<std::string>("URDFBOT.URDFBOT_PAWN.URDF_DIR")),

--- a/cpp/unreal_projects/SpearSim/Config/DefaultEngine.ini
+++ b/cpp/unreal_projects/SpearSim/Config/DefaultEngine.ini
@@ -29,6 +29,7 @@ r.Streaming.FullyLoadUsedTextures=1
 [/Script/EngineSettings.GameMapsSettings]
 GameDefaultMap=/Game/Scenes/default/Maps/DefaultMap.DefaultMap
 EditorStartupMap=/Game/Scenes/default/Maps/DefaultMap.DefaultMap
+GlobalDefaultGameMode=/Script/SpearSim.SpearSimGameMode
 
 [/Script/HardwareTargeting.HardwareTargetingSettings]
 TargetedHardwareClass=Desktop
@@ -49,3 +50,4 @@ bEnableLongPathsSupport=True
 ; For more information on GTSyncType, see http://docs.unrealengine.com/en-US/SharingAndReleasing/LowLatencyFrameSyncing/index.html.
 r.GTSyncType=1
 r.OneFrameThreadLag=0
+

--- a/cpp/unreal_projects/SpearSim/Source/SpearSim/SpearSimGameMode.cpp
+++ b/cpp/unreal_projects/SpearSim/Source/SpearSim/SpearSimGameMode.cpp
@@ -1,0 +1,14 @@
+//
+// Copyright(c) 2022 Intel. Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// Copyright Epic Games, Inc. All Rights Reserved.
+//
+
+#include "SpearSimGameMode.h"
+
+#include <GameFramework/SpectatorPawn.h>
+
+ASpearSimGameMode::ASpearSimGameMode(const FObjectInitializer& ObjectInitializer)
+    : Super(ObjectInitializer)
+{
+    DefaultPawnClass = ASpectatorPawn::StaticClass();
+}

--- a/cpp/unreal_projects/SpearSim/Source/SpearSim/SpearSimGameMode.h
+++ b/cpp/unreal_projects/SpearSim/Source/SpearSim/SpearSimGameMode.h
@@ -1,0 +1,22 @@
+//
+// Copyright(c) 2022 Intel. Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// Copyright Epic Games, Inc. All Rights Reserved.
+//
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/GameModeBase.h"
+
+#include "SpearSimGameMode.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class ASpearSimGameMode : public AGameModeBase
+{
+	GENERATED_BODY()
+public:
+    ASpearSimGameMode(const FObjectInitializer& ObjectInitializer);
+};


### PR DESCRIPTION
add config flag to allow fly around the scene when execute standalone-executable without `config.yaml`.
* add Config flag checking if `config.yaml` is provided;
* skip UObject constructor if it depends on Config;
* custom default GameMode with default Pawn of `ASpectatorPawn`.