### PR TITLE
improved behavior when double-clicking on the SpearSim executable

### DIFF
--- a/cpp/unreal_plugins/CoreUtils/Source/CoreUtils/Unreal.h
+++ b/cpp/unreal_plugins/CoreUtils/Source/CoreUtils/Unreal.h
@@ -14,6 +14,7 @@
 #include <GameFramework/Actor.h>
 #include <UObject/NameTypes.h>
 
+#include "CoreUtils/Assert.h"
 #include "CoreUtils/Std.h"
 
 class COREUTILS_API Unreal

--- a/cpp/unreal_plugins/OpenBot/Source/OpenBot/OpenBotPawn.cpp
+++ b/cpp/unreal_plugins/OpenBot/Source/OpenBot/OpenBotPawn.cpp
@@ -154,7 +154,7 @@ AOpenBotPawn::~AOpenBotPawn()
     std::cout << "[SPEAR | OpenBotPawn.cpp] AOpenBotPawn::~AOpenBotPawn" << std::endl;
 }
 
-void AOpenBotPawn::SetupPlayerInputComponent(class UInputComponent* input_component)
+void AOpenBotPawn::SetupPlayerInputComponent(UInputComponent* input_component)
 {
     ASSERT(input_component);
     APawn::SetupPlayerInputComponent(input_component);

--- a/cpp/unreal_plugins/UrdfBot/Source/UrdfBot/UrdfBot.cpp
+++ b/cpp/unreal_plugins/UrdfBot/Source/UrdfBot/UrdfBot.cpp
@@ -2,7 +2,7 @@
 // Copyright(c) 2022 Intel. Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 //
 
-#include "UrdfBot.h"
+#include "UrdfBot/UrdfBot.h"
 
 #include <iostream>
 

--- a/cpp/unreal_plugins/UrdfBot/Source/UrdfBot/UrdfBotPawn.cpp
+++ b/cpp/unreal_plugins/UrdfBot/Source/UrdfBot/UrdfBotPawn.cpp
@@ -60,9 +60,9 @@ AUrdfBotPawn::~AUrdfBotPawn()
     std::cout << "[SPEAR | UrdfBotPawn.cpp] AUrdfBotPawn::~AUrdfBotPawn" << std::endl;
 }
 
-void AUrdfBotPawn::SetupPlayerInputComponent(class UInputComponent* input_component)
+void AUrdfBotPawn::SetupPlayerInputComponent(UInputComponent* input_component)
 {
-    Super::SetupPlayerInputComponent(input_component);
+    APawn::SetupPlayerInputComponent(input_component);
 
     UPlayerInput* player_input = GetWorld()->GetFirstPlayerController()->PlayerInput;
     auto keyboard_actions = Config::get<std::map<std::string, std::map<std::string, std::map<std::string, float>>>>("URDFBOT.URDFBOT_PAWN.KEYBOARD_ACTIONS");
@@ -78,7 +78,7 @@ void AUrdfBotPawn::SetupPlayerInputComponent(class UInputComponent* input_compon
             keyboard_action.add_action_ = keyboard_action_config.second.at("ADD_ACTION");
         }
 
-        player_input->AddAxisMapping(FInputAxisKeyMapping(Unreal::toFName(keyboard_action.axis_), FKey(Unreal::toFName(keyboard_action_config.first)), 1));
+        player_input->AddAxisMapping(FInputAxisKeyMapping(Unreal::toFName(keyboard_action.axis_), FKey(Unreal::toFName(keyboard_action_config.first)), 1.0f));
         input_component->BindAxis(Unreal::toFName(keyboard_action.axis_));
 
         keyboard_actions_.push_back(keyboard_action);
@@ -87,7 +87,7 @@ void AUrdfBotPawn::SetupPlayerInputComponent(class UInputComponent* input_compon
 
 void AUrdfBotPawn::Tick(float delta_time)
 {
-    Super::Tick(delta_time);
+    APawn::Tick(delta_time);
 
     for (auto& keyboard_action : keyboard_actions_) {
         float axis_value = InputComponent->GetAxisValue(Unreal::toFName(keyboard_action.axis_));

--- a/cpp/unreal_plugins/UrdfBot/Source/UrdfBot/UrdfJointComponent.cpp
+++ b/cpp/unreal_plugins/UrdfBot/Source/UrdfBot/UrdfJointComponent.cpp
@@ -14,7 +14,7 @@
 
 void UUrdfJointComponent::BeginPlay()
 {
-    Super::BeginPlay();
+    UPhysicsConstraintComponent::BeginPlay();
 
     // SetConstrainedComponents(...) in constructor functions properly yet leads to warning message:
     //     Warning: Constraint in '/Script/UrdfBot.Default__UrdfBotPawn:AUrdfBotPawn::urdf_robot_component_.UrdfJointComponent_0'

--- a/cpp/unreal_plugins/UrdfBot/Source/UrdfBot/UrdfLinkComponent.cpp
+++ b/cpp/unreal_plugins/UrdfBot/Source/UrdfBot/UrdfLinkComponent.cpp
@@ -13,7 +13,7 @@
 
 void UUrdfLinkComponent::BeginPlay()
 {
-    Super::BeginPlay();
+    UStaticMeshComponent::BeginPlay();
 
     // set relative scale at `BeginPlay` to avoid propagating scale to child components
     SetRelativeScale3D(relative_scale_);

--- a/cpp/unreal_projects/SpearSim/Config/DefaultGameUserSettings.ini
+++ b/cpp/unreal_projects/SpearSim/Config/DefaultGameUserSettings.ini
@@ -1,0 +1,15 @@
+;
+; Copyright(c) 2022 Intel. Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+; Copyright Epic Games, Inc. All Rights Reserved.
+;
+
+[/Script/Engine.GameUserSettings]
+; For some reason, these resolution values need to be twice as big as the corresponding -resx and -resy command-line arguments
+; FullscreenMode=2 corresponds to windowed mode
+; Version=5 is necessary for the values in this file to not be ignored, see
+;     https://forums.unrealengine.com/t/defaultgameusersettings-ini-not-functional-anymore/297425/20
+bUseVSync=False
+ResolutionSizeX=2048
+ResolutionSizeY=2048
+FullscreenMode=2
+Version=5

--- a/cpp/unreal_projects/SpearSim/Source/SpearSim/SpearSim.Build.cs
+++ b/cpp/unreal_projects/SpearSim/Source/SpearSim/SpearSim.Build.cs
@@ -22,7 +22,7 @@ public class SpearSim : ModuleRules
         // everywhere.
         bEnableExceptions = true;
 
-        PublicDependencyModuleNames.AddRange(new string[] {"Core", "CoreUObject", "Engine"});
+        PublicDependencyModuleNames.AddRange(new string[] {"Core", "CoreUObject", "CoreUtils", "Engine"});
         PrivateDependencyModuleNames.AddRange(new string[] {});
     }
 }

--- a/cpp/unreal_projects/SpearSim/Source/SpearSim/SpearSim.cpp
+++ b/cpp/unreal_projects/SpearSim/Source/SpearSim/SpearSim.cpp
@@ -3,7 +3,8 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
 //
 
-#include "SpearSim.h"
+#include "SpearSim/SpearSim.h"
+
 #include <Modules/ModuleManager.h>
 
 IMPLEMENT_PRIMARY_GAME_MODULE(FDefaultGameModuleImpl, SpearSim, "SpearSim");

--- a/cpp/unreal_projects/SpearSim/Source/SpearSim/SpearSimGameMode.cpp
+++ b/cpp/unreal_projects/SpearSim/Source/SpearSim/SpearSimGameMode.cpp
@@ -3,12 +3,20 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
 //
 
-#include "SpearSimGameMode.h"
+#include "SpearSim/SpearSimGameMode.h"
 
-#include <GameFramework/SpectatorPawn.h>
+#include <iostream>
 
-ASpearSimGameMode::ASpearSimGameMode(const FObjectInitializer& ObjectInitializer)
-    : Super(ObjectInitializer)
+#include "SpearSim/SpearSimSpectatorPawn.h"
+
+ASpearSimGameMode::ASpearSimGameMode(const FObjectInitializer& object_initializer) : AGameModeBase(object_initializer)
 {
-    DefaultPawnClass = ASpectatorPawn::StaticClass();
+    std::cout << "[SPEAR | SpearSimGameMode.cpp] ASpearSimGameMode::ASpearSimGameMode" << std::endl;
+
+    DefaultPawnClass = ASpearSimSpectatorPawn::StaticClass();
+}
+
+ASpearSimGameMode::~ASpearSimGameMode()
+{
+    std::cout << "[SPEAR | SpearSimGameMode.cpp] ASpearSimGameMode::~ASpearSimGameMode" << std::endl;
 }

--- a/cpp/unreal_projects/SpearSim/Source/SpearSim/SpearSimGameMode.h
+++ b/cpp/unreal_projects/SpearSim/Source/SpearSim/SpearSimGameMode.h
@@ -5,18 +5,16 @@
 
 #pragma once
 
-#include "CoreMinimal.h"
-#include "GameFramework/GameModeBase.h"
+#include <CoreMinimal.h>
+#include <GameFramework/GameModeBase.h>
 
 #include "SpearSimGameMode.generated.h"
 
-/**
- * 
- */
 UCLASS()
 class ASpearSimGameMode : public AGameModeBase
 {
 	GENERATED_BODY()
 public:
-    ASpearSimGameMode(const FObjectInitializer& ObjectInitializer);
+    ASpearSimGameMode(const FObjectInitializer& object_initializer);
+    ~ASpearSimGameMode();
 };

--- a/cpp/unreal_projects/SpearSim/Source/SpearSim/SpearSimSpectatorPawn.cpp
+++ b/cpp/unreal_projects/SpearSim/Source/SpearSim/SpearSimSpectatorPawn.cpp
@@ -1,0 +1,46 @@
+//
+// Copyright(c) 2022 Intel. Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+//
+
+#include "SpearSim/SpearSimSpectatorPawn.h"
+
+#include <iostream>
+
+#include <Components/InputComponent.h>
+#include <GameFramework/PlayerInput.h>
+#include <GameFramework/SpectatorPawn.h>
+#include <GenericPlatform/GenericPlatformMisc.h>
+
+#include "CoreUtils/Config.h"
+#include "CoreUtils/Unreal.h"
+
+ASpearSimSpectatorPawn::ASpearSimSpectatorPawn(const FObjectInitializer& object_initializer) : ASpectatorPawn(object_initializer)
+{
+    std::cout << "[SPEAR | SpearSimSpectatorPawn.cpp] ASpearSimSpectatorPawn::ASpearSimSpectatorPawn" << std::endl;
+
+    if (!Config::s_initialized_) {
+        return;
+    }
+}
+
+ASpearSimSpectatorPawn::~ASpearSimSpectatorPawn()
+{
+    std::cout << "[SPEAR | SpearSimSpectatorPawn.cpp] ASpearSimSpectatorPawn::~ASpearSimSpectatorPawn" << std::endl;
+}
+
+void ASpearSimSpectatorPawn::SetupPlayerInputComponent(UInputComponent* input_component)
+{
+    ASpectatorPawn::SetupPlayerInputComponent(input_component);
+
+    UPlayerInput* player_input = GetWorld()->GetFirstPlayerController()->PlayerInput;
+    player_input->AddAxisMapping(FInputAxisKeyMapping(Unreal::toFName("Exit"), FKey(Unreal::toFName("Escape")), 1.0f));
+    input_component->BindAxis("Exit", this, &ASpearSimSpectatorPawn::exit);
+}
+
+void ASpearSimSpectatorPawn::exit(float value)
+{
+    if (value == 1.0f) {
+        bool force = false;
+        FGenericPlatformMisc::RequestExit(force);
+    }
+}

--- a/cpp/unreal_projects/SpearSim/Source/SpearSim/SpearSimSpectatorPawn.h
+++ b/cpp/unreal_projects/SpearSim/Source/SpearSim/SpearSimSpectatorPawn.h
@@ -1,0 +1,26 @@
+//
+// Copyright(c) 2022 Intel. Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+//
+
+#pragma once
+
+#include <CoreMinimal.h>
+#include <GameFramework/SpectatorPawn.h>
+
+#include "SpearSimSpectatorPawn.generated.h"
+
+class UInputComponent;
+
+UCLASS()
+class ASpearSimSpectatorPawn : public ASpectatorPawn
+{
+    GENERATED_BODY()
+public:
+    ASpearSimSpectatorPawn(const FObjectInitializer& object_initializer);
+    ~ASpearSimSpectatorPawn();
+
+    void SetupPlayerInputComponent(UInputComponent* input_component) override;
+
+private:
+    void exit(float value);
+};

--- a/tools/build_pak_files.py
+++ b/tools/build_pak_files.py
@@ -47,6 +47,8 @@ if __name__ == '__main__':
         platform          = "Linux"
         unreal_editor_bin = os.path.realpath(os.path.join(args.unreal_engine_dir, "Engine", "Binaries", "Linux", "UE4Editor"))
         unreal_pak_bin    = os.path.realpath(os.path.join(args.unreal_engine_dir, "Engine", "Binaries", "Linux", "UnrealPak"))
+    else:
+        assert False
 
     # once we know the platform, set our cooked dir
     unreal_project_cooked_dir = os.path.realpath(os.path.join(unreal_project_dir, "Saved", "Cooked", platform + "NoEditor"))


### PR DESCRIPTION
improved behavior when double-clicking on the SpearSim executable: runs in windowed mode, and the user can press escape to exit out of the application