### PR TITLE
implemented run_executable.py and other improvements 

### DIFF
--- a/cpp/unreal_plugins/CoreUtils/Source/CoreUtils/CoreUtils.Build.cs
+++ b/cpp/unreal_plugins/CoreUtils/Source/CoreUtils/CoreUtils.Build.cs
@@ -28,25 +28,10 @@ public class CoreUtils : ModuleRules
         PrivateDependencyModuleNames.AddRange(new string[] {});
 
         //
-        // Boost (predef, tokenizer)
+        // Boost
         //
 
-        // predef
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "predef", "include"));
-
-        // tokenizer
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "assert", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "config", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "core", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "detail", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "iterator", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "mpl", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "preprocessor", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "throw_exception", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "tokenizer", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "type_traits", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "static_assert", "include"));
-
+        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost"));
 
         //
         // rpclib

--- a/cpp/unreal_plugins/SimulationController/Source/SimulationController/SimulationController.Build.cs
+++ b/cpp/unreal_plugins/SimulationController/Source/SimulationController/SimulationController.Build.cs
@@ -30,37 +30,23 @@ public class SimulationController : ModuleRules
         // or Config::get(...).
         bEnableExceptions = true;
 
-        //
-        // Boost (asio, interprocess) 
-        //
-
-        // asio
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "align", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "asio", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "bind", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "date_time", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "exception", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "mpl", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "numeric", "conversion", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "preprocessor", "include"));        
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "regex", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "smart_ptr", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "system", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "throw_exception", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "type_traits", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "utility", "include"));
-
-        // interprocess
+         // Required for boost::interprocess
         bEnableUndefinedIdentifierWarnings = false;
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "assert", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "config", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "container", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "core", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "interprocess", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "intrusive", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "move", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "predef", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "static_assert", "include"));
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "libs", "winapi", "include"));
+
+        //
+        // Boost
+        //
+
+        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost"));
+
+        if (Target.Platform == UnrealTargetPlatform.Win64) {
+            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "stage", "lib", "libboost_filesystem.lib"));
+        } else if (Target.Platform == UnrealTargetPlatform.Mac) {
+            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "stage", "lib", "libboost_filesystem.a"));
+        } else if (Target.Platform == UnrealTargetPlatform.Linux) {
+            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "stage", "lib", "libboost_filesystem.a"));
+        } else {
+            throw new Exception("[SPEAR | CoreUtils.Build.cs] Target.Platform == " + Target.Platform);
+        }
     }
 }

--- a/cpp/unreal_plugins/SimulationController/Source/SimulationController/SimulationController.Build.cs
+++ b/cpp/unreal_plugins/SimulationController/Source/SimulationController/SimulationController.Build.cs
@@ -38,15 +38,5 @@ public class SimulationController : ModuleRules
         //
 
         PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost"));
-
-        if (Target.Platform == UnrealTargetPlatform.Win64) {
-            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "stage", "lib", "libboost_filesystem.lib"));
-        } else if (Target.Platform == UnrealTargetPlatform.Mac) {
-            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "stage", "lib", "libboost_filesystem.a"));
-        } else if (Target.Platform == UnrealTargetPlatform.Linux) {
-            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost", "stage", "lib", "libboost_filesystem.a"));
-        } else {
-            throw new Exception("[SPEAR | CoreUtils.Build.cs] Target.Platform == " + Target.Platform);
-        }
     }
 }

--- a/cpp/unreal_plugins/SimulationController/Source/SimulationController/SimulationController.cpp
+++ b/cpp/unreal_plugins/SimulationController/Source/SimulationController/SimulationController.cpp
@@ -115,8 +115,9 @@ void SimulationController::postWorldInitializationEventHandler(UWorld* world, co
         std::string level_name;
 
         std::string scene_id = Config::get<std::string>("SIMULATION_CONTROLLER.SCENE_ID");
+        std::string map_id = Config::get<std::string>("SIMULATION_CONTROLLER.MAP_ID");
+
         if (scene_id != "") {
-            std::string map_id = Config::get<std::string>("SIMULATION_CONTROLLER.MAP_ID");
             if (map_id == "") {
                 map_id = scene_id;
             } else {

--- a/cpp/unreal_plugins/SimulationController/Source/SimulationController/SimulationController.cpp
+++ b/cpp/unreal_plugins/SimulationController/Source/SimulationController/SimulationController.cpp
@@ -120,8 +120,6 @@ void SimulationController::postWorldInitializationEventHandler(UWorld* world, co
         if (scene_id != "") {
             if (map_id == "") {
                 map_id = scene_id;
-            } else {
-                map_id = scene_id;
             }
             world_path_name = "/Game/Scenes/" + scene_id + "/Maps/" + map_id + "." + map_id;
             level_name      = "/Game/Scenes/" + scene_id + "/Maps/" + map_id;            
@@ -165,10 +163,6 @@ void SimulationController::postWorldInitializationEventHandler(UWorld* world, co
 void SimulationController::worldBeginPlayEventHandler()
 {
     std::cout << "[SPEAR | SimulationController.cpp] SimulationController::worldBeginPlayEventHandler" << std::endl;
-
-    if (!Config::s_initialized_) {
-        return;
-    }
 
     // execute optional console commands from python client
     for (auto& command : Config::get<std::vector<std::string>>("SIMULATION_CONTROLLER.CUSTOM_UNREAL_CONSOLE_COMMANDS")) {
@@ -272,8 +266,10 @@ void SimulationController::worldCleanupEventHandler(UWorld* world, bool session_
         }
 
         // remove event handlers bound to this world before world gets cleaned up
-        world_->OnWorldBeginPlay.Remove(world_begin_play_delegate_handle_);
-        world_begin_play_delegate_handle_.Reset();
+        if (Config::get<std::string>("SIMULATION_CONTROLLER.INTERACTION_MODE") == "programmatic") {
+            world_->OnWorldBeginPlay.Remove(world_begin_play_delegate_handle_);
+            world_begin_play_delegate_handle_.Reset();
+        }
 
         // clear cached world_ pointer
         world_ = nullptr;

--- a/cpp/unreal_plugins/UrdfBot/Source/UrdfBot/UrdfBot.Build.cs
+++ b/cpp/unreal_plugins/UrdfBot/Source/UrdfBot/UrdfBot.Build.cs
@@ -24,7 +24,7 @@ public class UrdfBot : ModuleRules
         // everywhere.
         bEnableExceptions = true;
 
-        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "CoreUtils", "Engine", "InputCore", "Slate", "XmlParser", });
+        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "CoreUtils", "Engine", "InputCore", "Slate", "XmlParser" });
         PrivateDependencyModuleNames.AddRange(new string[] {});
 
         //

--- a/cpp/unreal_projects/SpearSim/Config/DefaultEngine.ini
+++ b/cpp/unreal_projects/SpearSim/Config/DefaultEngine.ini
@@ -8,7 +8,7 @@ ZeroEngineVersionWarning=False
 [/Script/Engine.Engine]
 +ActiveGameNameRedirects=(OldGameName="TP_Blank",NewGameName="/Script/SpearSim")
 +ActiveGameNameRedirects=(OldGameName="/Script/TP_Blank",NewGameName="/Script/SpearSim")
-+ActiveClassRedirects=(OldClassName="TP_BlankGameModeBase",NewClassName="SpearSimGameModeBase")
++ActiveClassRedirects=(OldClassName="TP_BlankGameModeBase",NewClassName="SpearSimGameMode")
 
 [/Script/Engine.PhysicsSettings]
 bEnableEnhancedDeterminism=True

--- a/cpp/unreal_projects/SpearSim/Config/DefaultGameUserSettings.ini
+++ b/cpp/unreal_projects/SpearSim/Config/DefaultGameUserSettings.ini
@@ -9,7 +9,7 @@
 ; Version=5 is necessary for the values in this file to not be ignored, see
 ;     https://forums.unrealengine.com/t/defaultgameusersettings-ini-not-functional-anymore/297425/20
 bUseVSync=False
-ResolutionSizeX=2048
-ResolutionSizeY=2048
+ResolutionSizeX=512
+ResolutionSizeY=512
 FullscreenMode=2
 Version=5

--- a/cpp/unreal_projects/SpearSim/Config/DefaultGameUserSettings.ini
+++ b/cpp/unreal_projects/SpearSim/Config/DefaultGameUserSettings.ini
@@ -3,13 +3,16 @@
 ; Copyright Epic Games, Inc. All Rights Reserved.
 ;
 
+; NOTE: The values in this file will be overridden by a local file maintained by the Unreal Engine (e.g.,
+; ~/Library/Preferences/SpearSim/MacNoEditor/GameUserSettings.ini on macOS), which gets written automatically
+; when SpearSim exits. Therefore, these values only specify the behavior of the executable the first time it
+; executes. After SpearSim has already been executed, we must override GameUserSettings.ini via the command-line.
+; See https://forums.unrealengine.com/t/defaultgameusersettings-ini-not-functional-anymore/297425/20 for more
+; details.
+
 [/Script/Engine.GameUserSettings]
-; For some reason, these resolution values need to be twice as big as the corresponding -resx and -resy command-line arguments
-; FullscreenMode=2 corresponds to windowed mode
-; Version=5 is necessary for the values in this file to not be ignored, see
-;     https://forums.unrealengine.com/t/defaultgameusersettings-ini-not-functional-anymore/297425/20
 bUseVSync=False
-ResolutionSizeX=512
-ResolutionSizeY=512
-FullscreenMode=2
-Version=5
+ResolutionSizeX=1024 
+ResolutionSizeY=1024
+FullscreenMode=2 ; FullscreenMode=2 is windowed mode
+Version=5        ; Version=5 is required so the values in this file are not ignored

--- a/examples/generate_image_dataset/generate_images.py
+++ b/examples/generate_image_dataset/generate_images.py
@@ -57,8 +57,8 @@ class CustomEnv(spear.Env):
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--poses_file", default=os.path.join(os.path.dirname(os.path.realpath(__file__)), "poses.csv"))
-    parser.add_argument("--images_dir", default=os.path.join(os.path.dirname(os.path.realpath(__file__)), "images"))
+    parser.add_argument("--poses_file", default=os.path.realpath(os.path.join(os.path.dirname(__file__), "poses.csv")))
+    parser.add_argument("--images_dir", default=os.path.realpath(os.path.join(os.path.dirname(__file__), "images")))
     parser.add_argument("--rendering_mode", default="baked")
     parser.add_argument("--num_internal_steps", type=int)
     parser.add_argument("--benchmark", action="store_true")
@@ -66,7 +66,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # load config
-    config = spear.get_config(user_config_files=[os.path.join(os.path.dirname(os.path.realpath(__file__)), "user_config.yaml")])
+    config = spear.get_config(user_config_files=[os.path.realpath(os.path.join(os.path.dirname(__file__), "user_config.yaml"))])
 
     # read data from csv
     df = pd.read_csv(args.poses_file, dtype={"scene_id":str})
@@ -107,30 +107,25 @@ if __name__ == "__main__":
             # create dir for storing images
             if not args.benchmark:
                 for render_pass in config.SIMULATION_CONTROLLER.CAMERA_AGENT.CAMERA.RENDER_PASSES:
-                    render_pass_dir = os.path.join(args.images_dir, render_pass)
+                    render_pass_dir = os.path.realpath(os.path.join(args.images_dir, render_pass))
                     os.makedirs(render_pass_dir, exist_ok=True)
 
             # change config based on current scene
             config.defrost()
 
             if pose["scene_id"] == "kujiale_0000":
-                config.SIMULATION_CONTROLLER.WORLD_PATH_NAME = \
-                    "/Game/Scenes/" + pose["scene_id"] + "/Maps/" + pose["scene_id"] + rendering_mode_map_str + "." + pose["scene_id"] + rendering_mode_map_str
-                config.SIMULATION_CONTROLLER.LEVEL_NAME = \
-                    "/Game/Scenes/" + pose["scene_id"] + "/Maps/" + pose["scene_id"] + rendering_mode_map_str
+                config.SIMULATION_CONTROLLER.SCENE_ID = pose["scene_id"]
+                config.SIMULATION_CONTROLLER.MAP_ID   = pose["scene_id"] + rendering_mode_map_str
 
                 # kujiale_0000 has scene-specific config values
-                scene_config_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "scene_config.kujiale_0000.yaml")
+                scene_config_file = os.path.realpath(os.path.join(os.path.dirname(__file__), "scene_config.kujiale_0000.yaml"))
 
             elif pose["scene_id"] == "warehouse_0000":
-                # warehouse_0000 doesn't need a rendering mode when referring to its map
-                config.SIMULATION_CONTROLLER.WORLD_PATH_NAME = \
-                    "/Game/Scenes/" + pose["scene_id"] + "/Maps/" + pose["scene_id"] + "." + pose["scene_id"]
-                config.SIMULATION_CONTROLLER.LEVEL_NAME = \
-                    "/Game/Scenes/" + pose["scene_id"] + "/Maps/" + pose["scene_id"]
+                config.SIMULATION_CONTROLLER.SCENE_ID = pose["scene_id"]
+                config.SIMULATION_CONTROLLER.MAP_ID   = pose["scene_id"]
 
                 # warehouse_0000 has scene-specific config values
-                scene_config_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "scene_config.warehouse_0000.yaml")
+                scene_config_file = os.path.realpath(os.path.join(os.path.dirname(__file__), "scene_config.warehouse_0000.yaml"))
 
             config.merge_from_file(scene_config_file)
             config.SIMULATION_CONTROLLER.SCENE_ID = pose["scene_id"]
@@ -156,7 +151,7 @@ if __name__ == "__main__":
         # save images for each render pass
         if not args.benchmark:
             for render_pass in config.SIMULATION_CONTROLLER.CAMERA_AGENT.CAMERA.RENDER_PASSES:
-                render_pass_dir = os.path.join(args.images_dir, render_pass)
+                render_pass_dir = os.path.realpath(os.path.join(args.images_dir, render_pass))
                 assert os.path.exists(render_pass_dir)
 
                 obs_render_pass = obs["camera." + render_pass].squeeze()
@@ -164,7 +159,7 @@ if __name__ == "__main__":
                     assert obs_render_pass.shape[2] == 4
                     obs_render_pass = obs_render_pass[:,:,[2,1,0,3]].copy() # note that spear.Env returns BGRA by default
 
-                plt.imsave(os.path.join(render_pass_dir, "%04d.png"%pose["index"]), obs_render_pass)
+                plt.imsave(os.path.realpath(os.path.join(render_pass_dir, "%04d.png"%pose["index"])), obs_render_pass)
 
         # useful for comparing the game window to the image that has been saved to disk
         if args.wait_for_key_press:

--- a/examples/generate_image_dataset/generate_poses.py
+++ b/examples/generate_image_dataset/generate_poses.py
@@ -15,17 +15,17 @@ import spear
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--poses_file", default=os.path.join(os.path.dirname(os.path.realpath(__file__)), "poses.csv"))
+    parser.add_argument("--poses_file", default=os.path.realpath(os.path.join(os.path.dirname(__file__), "poses.csv")))
     parser.add_argument("--num_poses_per_scene", type=int, default=10)
     parser.add_argument("--scene_id")
     args = parser.parse_args()
 
     # load config
-    config = spear.get_config(user_config_files=[os.path.join(os.path.dirname(os.path.realpath(__file__)), "user_config.yaml")])
+    config = spear.get_config(user_config_files=[os.path.realpath(os.path.join(os.path.dirname(__file__), "user_config.yaml"))])
 
     # if the user provides a scene_id, use it, otherwise use the scenes defined in scenes.csv
     if args.scene_id is None:
-        scenes_csv_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "scenes.csv")
+        scenes_csv_file = os.path.realpath(os.path.join(os.path.dirname(__file__), "scenes.csv"))
         assert os.path.exists(scenes_csv_file)
         scene_ids = pd.read_csv(scenes_csv_file, dtype={"scene_id":str})["scene_id"]
     else:
@@ -40,23 +40,18 @@ if __name__ == "__main__":
         config.defrost()
 
         if scene_id == "kujiale_0000":
-            config.SIMULATION_CONTROLLER.WORLD_PATH_NAME = \
-                "/Game/Scenes/" + scene_id + "/Maps/" + scene_id + "_bake" + "." + scene_id + "_bake"
-            config.SIMULATION_CONTROLLER.LEVEL_NAME = \
-                "/Game/Scenes/" + scene_id + "/Maps/" + scene_id + "_bake"
+            config.SIMULATION_CONTROLLER.SCENE_ID = scene_id
+            config.SIMULATION_CONTROLLER.MAP_ID   = scene_id + "_bake"
 
             # kujiale_0000 has scene-specific config values
-            scene_config_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "scene_config.kujiale_0000.yaml")
+            scene_config_file = os.path.realpath(os.path.join(os.path.dirname(__file__), "scene_config.kujiale_0000.yaml"))
 
         elif scene_id == "warehouse_0000":
-            # warehouse_0000 doesn't need a rendering mode when referring to its map
-            config.SIMULATION_CONTROLLER.WORLD_PATH_NAME = \
-                "/Game/Scenes/" + scene_id + "/Maps/" + scene_id + "." + scene_id
-            config.SIMULATION_CONTROLLER.LEVEL_NAME = \
-                "/Game/Scenes/" + scene_id + "/Maps/" + scene_id
+            config.SIMULATION_CONTROLLER.SCENE_ID = scene_id
+            config.SIMULATION_CONTROLLER.MAP_ID   = scene_id
 
             # warehouse_0000 has scene-specific config values
-            scene_config_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "scene_config.warehouse_0000.yaml")
+            scene_config_file = os.path.realpath(os.path.join(os.path.dirname(__file__), "scene_config.warehouse_0000.yaml"))
 
         config.merge_from_file(scene_config_file)
         config.SIMULATION_CONTROLLER.SCENE_ID = scene_id

--- a/examples/generate_image_dataset/user_config.yaml.example
+++ b/examples/generate_image_dataset/user_config.yaml.example
@@ -7,9 +7,7 @@ SPEAR:
 
   STANDALONE_EXECUTABLE: "/Users/mroberts/Downloads/SpearSim-Mac-Shipping/SpearSim-Mac-Shipping.app"
 
-  DATA_DIR: "/Users/mroberts/Downloads/spear_data"
-
-  CONTENT_DIR: "/Users/mroberts/Downloads/SpearSim-Mac-Shipping/SpearSim-Mac-Shipping.app/Contents/UE4/SpearSim/Content"
+  DATA_DIR: "/Users/mroberts/Downloads/spear-data"
 
   CUSTOM_COMMAND_LINE_ARGUMENTS: []
   RENDER_OFFSCREEN: False

--- a/examples/getting_started/run.py
+++ b/examples/getting_started/run.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     np.set_printoptions(linewidth=200)
 
     # load config
-    config = spear.get_config(user_config_files=[os.path.join(os.path.dirname(os.path.realpath(__file__)), "user_config.yaml")])
+    config = spear.get_config(user_config_files=[os.path.realpath(os.path.join(os.path.dirname(__file__), "user_config.yaml"))])
 
     # create Env object
     env = spear.Env(config)

--- a/examples/getting_started/user_config.yaml.example
+++ b/examples/getting_started/user_config.yaml.example
@@ -17,8 +17,7 @@ SIMULATION_CONTROLLER:
   AGENT: "SphereAgent" # "SphereAgent" or "OpenBotAgent"
   CUSTOM_UNREAL_CONSOLE_COMMANDS: []
 
-  WORLD_PATH_NAME: "/Game/Scenes/starter_content_0000/Maps/starter_content_0000.starter_content_0000"
-  LEVEL_NAME: "/Game/Scenes/starter_content_0000/Maps/starter_content_0000"
+  SCENE_ID: "starter_content_0000"
 
   OPENBOT_AGENT:
     OPENBOT_ACTOR_NAME: "OpenBotActor"

--- a/examples/imitation_learning_openbot/generate_episodes.py
+++ b/examples/imitation_learning_openbot/generate_episodes.py
@@ -16,18 +16,18 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--num_episodes_per_scene", type=int, default=10)
-    parser.add_argument("--episodes_file", default=os.path.join(os.path.dirname(os.path.realpath(__file__)), "train_episodes.csv"))
+    parser.add_argument("--episodes_file", default=os.path.realpath(os.path.join(os.path.dirname(__file__), "train_episodes.csv")))
     parser.add_argument("--scene_id")
     args = parser.parse_args()
 
     # directory for trajectory image storage
     split_name = os.path.splitext(os.path.basename(args.episodes_file))[0] # isolate filename and remove extension
-    episodes_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "episodes")
-    split_dir = os.path.join(episodes_dir, split_name)
+    episodes_dir = os.path.realpath(os.path.join(os.path.dirname(__file__), "episodes"))
+    split_dir = os.path.realpath(os.path.join(episodes_dir, split_name))
     os.makedirs(split_dir, exist_ok=True)
 
     # load config
-    config = spear.get_config(user_config_files=[os.path.join(os.path.dirname(os.path.realpath(__file__)), "user_config.yaml")])
+    config = spear.get_config(user_config_files=[os.path.realpath(os.path.join(os.path.dirname(__file__), "user_config.yaml"))])
 
     # make sure that we are in trajectory sampling mode
     config.defrost()
@@ -36,7 +36,7 @@ if __name__ == "__main__":
 
     # if the user provides a scene_id, use it, otherwise use the scenes defined in scenes.csv
     if args.scene_id is None:
-        scenes_csv_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "scenes.csv")
+        scenes_csv_file = os.path.realpath(os.path.join(os.path.dirname(__file__), "scenes.csv"))
         assert os.path.exists(scenes_csv_file)
         scene_ids = pd.read_csv(scenes_csv_file, dtype={"scene_id":str})["scene_id"]
     else:
@@ -51,23 +51,18 @@ if __name__ == "__main__":
         config.defrost()
 
         if scene_id == "kujiale_0000":
-            config.SIMULATION_CONTROLLER.WORLD_PATH_NAME = \
-                "/Game/Scenes/" + scene_id + "/Maps/" + scene_id + "_bake" + "." + scene_id + "_bake"
-            config.SIMULATION_CONTROLLER.LEVEL_NAME = \
-                "/Game/Scenes/" + scene_id + "/Maps/" + scene_id + "_bake"
+            config.SIMULATION_CONTROLLER.SCENE_ID = scene_id
+            config.SIMULATION_CONTROLLER.MAP_ID   = scene_id + "_bake"
 
             # kujiale_0000 has scene-specific config values
-            scene_config_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "scene_config.kujiale_0000.yaml")
+            scene_config_file = os.path.realpath(os.path.join(os.path.dirname(__file__), "scene_config.kujiale_0000.yaml"))
 
         elif scene_id == "warehouse_0000":
-            # warehouse_0000 doesn't need a rendering mode when referring to its map
-            config.SIMULATION_CONTROLLER.WORLD_PATH_NAME = \
-                "/Game/Scenes/" + scene_id + "/Maps/" + scene_id + "." + scene_id
-            config.SIMULATION_CONTROLLER.LEVEL_NAME = \
-                "/Game/Scenes/" + scene_id + "/Maps/" + scene_id
+            config.SIMULATION_CONTROLLER.SCENE_ID = scene_id
+            config.SIMULATION_CONTROLLER.MAP_ID   = scene_id
 
             # warehouse_0000 has scene-specific config values
-            scene_config_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "scene_config.warehouse_0000.yaml")
+            scene_config_file = os.path.realpath(os.path.join(os.path.dirname(__file__), "scene_config.warehouse_0000.yaml"))
 
         config.merge_from_file(scene_config_file)
         config.SIMULATION_CONTROLLER.SCENE_ID = scene_id
@@ -120,7 +115,7 @@ if __name__ == "__main__":
         plt.grid()
         plt.title(f"scene_id {scene_id}")
         
-        plt.savefig(os.path.join(split_dir, scene_id), bbox_extra_artists=[legend], bbox_inches="tight")
+        plt.savefig(os.path.realpath(os.path.join(split_dir, scene_id)), bbox_extra_artists=[legend], bbox_inches="tight")
 
         # close the current scene
         env.close()

--- a/examples/imitation_learning_openbot/run_trained_policy.py
+++ b/examples/imitation_learning_openbot/run_trained_policy.py
@@ -22,9 +22,9 @@ if __name__ == "__main__":
     # parse arguments
     parser = argparse.ArgumentParser()
     parser.add_argument("--num_iterations_per_episode", type=int, default=500)
-    parser.add_argument("--episodes_file", default=os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_episodes.csv"))
-    parser.add_argument("--policy_file", default=os.path.join(os.path.dirname(os.path.realpath(__file__)), "models", "test.tflite"))
-    parser.add_argument("--eval_dir", default=os.path.join(os.path.dirname(os.path.realpath(__file__)), "eval"))
+    parser.add_argument("--episodes_file", default=os.path.realpath(os.path.join(os.path.dirname(__file__), "test_episodes.csv")))
+    parser.add_argument("--policy_file", default=os.path.realpath(os.path.join(os.path.dirname(__file__), "models", "test.tflite")))
+    parser.add_argument("--eval_dir", default=os.path.realpath(os.path.join(os.path.dirname(__file__), "eval")))
     parser.add_argument("--rendering_mode", default="baked")
     parser.add_argument("--create_videos", action="store_true")
     parser.add_argument("--benchmark", action="store_true")
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     
     # load config
-    config = spear.get_config(user_config_files=[os.path.join(os.path.dirname(os.path.realpath(__file__)), "user_config.yaml")])
+    config = spear.get_config(user_config_files=[os.path.realpath(os.path.join(os.path.dirname(__file__), "user_config.yaml"))])
 
     # make sure that we are not in trajectory sampling mode
     config.defrost()
@@ -116,23 +116,18 @@ if __name__ == "__main__":
             config.defrost()
 
             if episode["scene_id"] == "kujiale_0000":
-                config.SIMULATION_CONTROLLER.WORLD_PATH_NAME = \
-                    "/Game/Scenes/" + episode["scene_id"] + "/Maps/" + episode["scene_id"] + rendering_mode_map_str + "." + episode["scene_id"] + rendering_mode_map_str
-                config.SIMULATION_CONTROLLER.LEVEL_NAME = \
-                    "/Game/Scenes/" + episode["scene_id"] + "/Maps/" + episode["scene_id"] + rendering_mode_map_str
+                config.SIMULATION_CONTROLLER.SCENE_ID = episode["scene_id"]
+                config.SIMULATION_CONTROLLER.MAP_ID   = episode["scene_id"] + rendering_mode_map_str
 
                 # kujiale_0000 has scene-specific config values
-                scene_config_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "scene_config.kujiale_0000.yaml")
+                scene_config_file = os.path.realpath(os.path.join(os.path.dirname(__file__), "scene_config.kujiale_0000.yaml"))
 
             elif episode["scene_id"] == "warehouse_0000":
-                # warehouse_0000 doesn't need a rendering mode when referring to its map
-                config.SIMULATION_CONTROLLER.WORLD_PATH_NAME = \
-                    "/Game/Scenes/" + episode["scene_id"] + "/Maps/" + episode["scene_id"] + "." + episode["scene_id"]
-                config.SIMULATION_CONTROLLER.LEVEL_NAME = \
-                    "/Game/Scenes/" + episode["scene_id"] + "/Maps/" + episode["scene_id"]
+                config.SIMULATION_CONTROLLER.SCENE_ID = episode["scene_id"]
+                config.SIMULATION_CONTROLLER.MAP_ID   = episode["scene_id"]
 
                 # warehouse_0000 has scene-specific config values
-                scene_config_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "scene_config.warehouse_0000.yaml")
+                scene_config_file = os.path.realpath(os.path.join(os.path.dirname(__file__), "scene_config.warehouse_0000.yaml"))
 
             config.merge_from_file(scene_config_file)
             config.SIMULATION_CONTROLLER.SCENE_ID = episode["scene_id"]
@@ -159,11 +154,11 @@ if __name__ == "__main__":
             start_time_seconds = time.time()
         else:
             # create dirs for storing data
-            scene_dir = os.path.join(args.eval_dir, episode["scene_id"])
-            episode_dir = os.path.join(scene_dir, "%04d" % episode["index"])
-            image_dir = os.path.join(episode_dir, "images")
-            result_dir = os.path.join(episode_dir, "results")
-            plots_dir = os.path.join(episode_dir, "plots")
+            scene_dir = os.path.realpath(os.path.join(args.eval_dir, episode["scene_id"]))
+            episode_dir = os.path.realpath(os.path.join(scene_dir, "%04d" % episode["index"]))
+            image_dir = os.path.realpath(os.path.join(episode_dir, "images"))
+            result_dir = os.path.realpath(os.path.join(episode_dir, "results"))
+            plots_dir = os.path.realpath(os.path.join(episode_dir, "plots"))
             os.makedirs(image_dir, exist_ok=True)
             os.makedirs(result_dir, exist_ok=True)
             os.makedirs(plots_dir, exist_ok=True)
@@ -175,7 +170,7 @@ if __name__ == "__main__":
             df_trajectory = pd.DataFrame({"x_d[cm]" : [env_step_info["agent_step_info"]["trajectory_data"][:,0]],
                                           "y_d[cm]" : [env_step_info["agent_step_info"]["trajectory_data"][:,1]],
                                           "z_d[cm]" : [env_step_info["agent_step_info"]["trajectory_data"][:,2]]})
-            df_trajectory.to_csv(os.path.join(result_dir,"trajectoryLog.txt"), mode="w", index=False, header=True)
+            df_trajectory.to_csv(os.path.realpath(os.path.join(result_dir,"trajectoryLog.txt")), mode="w", index=False, header=True)
 
         # execute the desired number of iterations in a given episode
         num_iterations = 0
@@ -199,7 +194,7 @@ if __name__ == "__main__":
                 obs_final_color = obs_final_color[:,:,[2,1,0,3]].copy() # note that spear.Env returns BGRA by default
 
                 # save the collected rgb observations
-                plt.imsave(os.path.join(image_dir, "%04d.jpg"%i), obs_final_color)
+                plt.imsave(os.path.realpath(os.path.join(image_dir, "%04d.jpg"%i)), obs_final_color)
 
                 # populate buffer and result data file
                 state_data[i] = obs["state_data"]
@@ -216,7 +211,7 @@ if __name__ == "__main__":
                                           "goal_z[cm]"   : goal[2],
                                           "goal_reached" : policy_step_info["goal_reached"],
                                           "hit_obstacle" : env_step_info["task_step_info"]["hit_obstacle"]})
-                df_result.to_csv(os.path.join(result_dir,"resultLog.txt"), mode="a", index=False, header=i==0)
+                df_result.to_csv(os.path.realpath(os.path.join(result_dir,"resultLog.txt")), mode="a", index=False, header=i==0)
             
             # debug
             if args.debug:
@@ -240,20 +235,22 @@ if __name__ == "__main__":
             end_time_seconds = time.time()
             elapsed_time_seconds = end_time_seconds - start_time_seconds
             print("[SPEAR | run_trained_policy.py] Average frame time: %0.4f ms (%0.4f fps)" %
-                ((elapsed_time_seconds / num_iterations)*1000, num_iterations / elapsed_time_seconds))
+                ((elapsed_time_seconds / num_iterations)*1000.0, num_iterations / elapsed_time_seconds))
             continue
 
         # create plots
         plot_tracking_performance_spatial(
-            state_data[:num_iterations][:], env_step_info["agent_step_info"]["trajectory_data"], os.path.join(plots_dir, "tracking_performance_spatial.png"))
+            state_data[:num_iterations][:],
+            env_step_info["agent_step_info"]["trajectory_data"],
+            os.path.realpath(os.path.join(plots_dir, "tracking_performance_spatial.png")))
 
         if args.create_videos: # if desired, generate a video from the collected rgb observations 
-            video_dir = os.path.join(args.eval_dir, "videos")
+            video_dir = os.path.realpath(os.path.join(args.eval_dir, "videos"))
             os.makedirs(video_dir, exist_ok=True)
             generate_video(
                 image_dir,
-                os.path.join(video_dir, "%04d.mp4" % episode["index"]),
-                rate=int(1/config.SIMULATION_CONTROLLER.SIMULATION_STEP_TIME_SECONDS), compress=True)
+                os.path.realpath(os.path.join(video_dir, "%04d.mp4" % episode["index"])),
+                rate=int(1.0/config.SIMULATION_CONTROLLER.SIMULATION_STEP_TIME_SECONDS), compress=True)
         
     # close the current scene
     env.close()

--- a/examples/imitation_learning_openbot/user_config.yaml.example
+++ b/examples/imitation_learning_openbot/user_config.yaml.example
@@ -19,9 +19,7 @@ SPEAR:
 
   STANDALONE_EXECUTABLE: "/Users/mroberts/Downloads/SpearSim-Mac-Shipping/SpearSim-Mac-Shipping.app"
 
-  DATA_DIR: "/Users/mroberts/Downloads/spear_data"
-
-  CONTENT_DIR: "/Users/mroberts/Downloads/SpearSim-Mac-Shipping/SpearSim-Mac-Shipping.app/Contents/UE4/SpearSim/Content"
+  DATA_DIR: "/Users/mroberts/Downloads/spear-data"
 
   CUSTOM_COMMAND_LINE_ARGUMENTS: []
   RENDER_OFFSCREEN: False
@@ -48,7 +46,7 @@ SIMULATION_CONTROLLER:
       IMAGE_WIDTH: 160
       FOV: 70.0
       RENDER_PASSES: ["final_color"] # "depth", "final_color", "normals", "segmentation"
-  
+
   IMITATION_LEARNING_TASK:
     AGENT_ACTOR_NAME: "OpenBotActor"
     GOAL_ACTOR_NAME: "GoalActor"

--- a/examples/imitation_learning_openbot/utils.py
+++ b/examples/imitation_learning_openbot/utils.py
@@ -92,7 +92,7 @@ def generate_video(image_dir, video_path, rate, compress=False):
     else:
         process = ffmpeg.input("pipe:", r=rate, f="jpeg_pipe").output(video_path, vcodec="libx264").overwrite_output().run_async(pipe_stdin=True)
     
-    images = [os.path.realpath(os.path.join(image_dir, img)) for img in sorted(os.listdir(image_dir))]
+    images = [ os.path.realpath(os.path.join(image_dir, img)) for img in sorted(os.listdir(image_dir)) ]
     for image in images:
         with open(image, "rb") as f:
             jpg_data = f.read()

--- a/examples/imitation_learning_openbot/utils.py
+++ b/examples/imitation_learning_openbot/utils.py
@@ -92,7 +92,7 @@ def generate_video(image_dir, video_path, rate, compress=False):
     else:
         process = ffmpeg.input("pipe:", r=rate, f="jpeg_pipe").output(video_path, vcodec="libx264").overwrite_output().run_async(pipe_stdin=True)
     
-    images = [os.path.join(image_dir, img) for img in sorted(os.listdir(image_dir))]
+    images = [os.path.realpath(os.path.join(image_dir, img)) for img in sorted(os.listdir(image_dir))]
     for image in images:
         with open(image, "rb") as f:
             jpg_data = f.read()

--- a/examples/open_loop_control_fetch/generate_actions.py
+++ b/examples/open_loop_control_fetch/generate_actions.py
@@ -9,6 +9,7 @@ import os
 import numpy as np
 import pandas as pd
 
+
 # fetch arm poses come from https://github.com/StanfordVL/iGibson/blob/master/igibson/robots/fetch.py#L100
 arm_poses = {
     "init": np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
@@ -58,7 +59,7 @@ def get_action(move_forward=0.0, move_right=0.0, gripper_force=50.0, arm_pose_bl
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--actions_file", default=os.path.join(os.path.dirname(os.path.realpath(__file__)), "actions.csv"))
+    parser.add_argument("--actions_file", default=os.path.realpath(os.path.join(os.path.dirname(__file__), "actions.csv")))
     args = parser.parse_args()
 
     df = pd.DataFrame()

--- a/examples/open_loop_control_fetch/run.py
+++ b/examples/open_loop_control_fetch/run.py
@@ -17,17 +17,16 @@ import time
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--actions_file", default=os.path.join(os.path.dirname(os.path.realpath(__file__)), "actions.csv"))
+    parser.add_argument("--actions_file", default=os.path.realpath(os.path.join(os.path.dirname(__file__), "actions.csv")))
     parser.add_argument("--save_images", default=True)
-    parser.add_argument("--image_dir", default=os.path.join(os.path.dirname(os.path.realpath(__file__)), "images"))
+    parser.add_argument("--image_dir", default=os.path.realpath(os.path.join(os.path.dirname(__file__), "images")))
     parser.add_argument("--benchmark", action="store_true")
     args = parser.parse_args()
 
     np.set_printoptions(linewidth=200)
 
     # load config
-    config = spear.get_config(
-        user_config_files=[os.path.join(os.path.dirname(os.path.realpath(__file__)), "user_config.yaml")])
+    config = spear.get_config(user_config_files=[os.path.realpath(os.path.join(os.path.dirname(__file__), "user_config.yaml"))])
 
     # get pregenerated actions for fetch urdf agent
     df = pd.read_csv(args.actions_file)
@@ -58,7 +57,7 @@ if __name__ == "__main__":
             cv2.waitKey(1)
 
         if args.save_images:
-            cv2.imwrite(os.path.join(args.image_dir, f"{i:04d}.jpg"), obs["camera.final_color"])
+            cv2.imwrite(os.path.realpath(os.path.join(args.image_dir, f"{i:04d}.jpg")), obs["camera.final_color"])
 
         if done:
             env.reset()

--- a/examples/open_loop_control_fetch/user_config.yaml.example
+++ b/examples/open_loop_control_fetch/user_config.yaml.example
@@ -5,7 +5,7 @@
 SPEAR:
   LAUNCH_MODE: "standalone_executable"
 
-  STANDALONE_EXECUTABLE: "E:/intel/interiorsim/dist/Standalone-Development/WindowsNoEditor/SpearSim/Binaries/Win64/SpearSim-Cmd.exe"
+  STANDALONE_EXECUTABLE: "/Users/mroberts/Downloads/SpearSim-Mac-Shipping/SpearSim-Mac-Shipping.app"
 
   CUSTOM_COMMAND_LINE_ARGUMENTS: []
   RENDER_OFFSCREEN: False
@@ -19,8 +19,7 @@ SIMULATION_CONTROLLER:
   AGENT: "UrdfBotAgent"
   CUSTOM_UNREAL_CONSOLE_COMMANDS: []
 
-  WORLD_PATH_NAME: "/Game/Scenes/starter_content_0000/Maps/starter_content_0000.starter_content_0000"
-  LEVEL_NAME: "/Game/Scenes/starter_content_0000/Maps/starter_content_0000"
+  SCENE_ID: "starter_content_0000"
 
   URDFBOT_AGENT:
     URDFBOT_ACTOR_NAME: "UrdfBotActor"

--- a/python/spear/config/default_config.simulation_controller.yaml
+++ b/python/spear/config/default_config.simulation_controller.yaml
@@ -3,11 +3,17 @@
 #
 
 SIMULATION_CONTROLLER:
+
+  INTERACTION_MODE: "programmatic" # "interactive", "programmatic"
+
+  # Setting SCENE_ID and MAP_ID will load the following map: /Game/Scenes/SCENE_ID/Maps/MAP_ID.MAP_ID
+  # If SCENE_ID is not set, the default map will be loaded. If MAP_ID is not set, it will be set to SCENE_ID.
+  SCENE_ID: "" 
+  MAP_ID: ""
+
   IP: "127.0.0.1"
   PORT: 30000
-  WORLD_PATH_NAME: "" # full path to the map including the repeated name, e.g., "/Game/Scenes/default/Maps/DefaultMap.DefaultMap"
-  LEVEL_NAME: ""      # full path to the map excluding the repeated name, e.g., "/Game/Scenes/default/Maps/DefaultMap"
-  SCENE_ID: ""        # raw map id, e.g. "DefaultMap"
+
   SIMULATION_STEP_TIME_SECONDS: 0.1
   TASK: ""
   AGENT: ""

--- a/python/spear/config/default_config.spear.yaml
+++ b/python/spear/config/default_config.spear.yaml
@@ -19,16 +19,9 @@ SPEAR:
   # If launch_mode is "uproject", specify this path to your uproject file.
   UPROJECT: ""
 
-  # "The location of downloaded scenes obtained from our scene_downloader tool including the
-  # version and platform, e.g., /Users/mroberts/Downloads/spear_data/v7/mac"
+  # The location of downloaded (or built) pak files. This must be specified if you are attempting
+  # to load any scene other than the default scene.
   DATA_DIR: ""
-
-  # The location of the Content directory corresponding to your Unreal executable. This is
-  # only needed if DATA_DIR is specified, in which case it is required. For example:
-  # - Windows: C:/Users/ADAS/repos/spear/code/unreal_projects/SpearSim/Standalone-Development/WindowsNoEditor/SpearSim/Content
-  # - macOS: /Users/mroberts/code/github/spear/code/unreal_projects/SpearSim/Standalone-Shipping/MacNoEditor/SpearSim-Mac-Shipping.app/Contents/UE4/SpearSim/Content
-  # - Linux: /home/mroberts/code/github/spear/unreal_projects/SpearSim/Standalone-Shipping/LinuxNoEditor/SpearSim/Content"
-  CONTENT_DIR:
 
   # Set this parameter to true True to launch the executable in headless mode. Has no effect
   # if launch_mode is "running_instance".
@@ -37,8 +30,8 @@ SPEAR:
   # If not running in headless mode, these parameters specify the window resolution used for
   # on-screen rendering. Has no effect on the size of the visual observations returned by the
   # application via the RPC server.
-  WINDOW_RESOLUTION_X: 512
-  WINDOW_RESOLUTION_Y: 512
+  WINDOW_RESOLUTION_X: 1024
+  WINDOW_RESOLUTION_Y: 1024
   
   # Launch your Unreal application on the GPU specified by GPU_ID.
   GPU_ID: 0

--- a/python/spear/env.py
+++ b/python/spear/env.py
@@ -111,16 +111,20 @@ class Env(gym.Env):
             self._config.dump(stream=output, default_flow_style=False)
 
         # create a symlink to SPEAR.DATA_DIR
-        if self._config.SPEAR.DATA_DIR != "":
+        if self._config.SPEAR.LAUNCH_MODE == "standalone_executable" and self._config.SPEAR.DATA_DIR != "":
 
+            assert os.path.exists(self._config.SPEAR.STANDALONE_EXECUTABLE)
             assert os.path.exists(self._config.SPEAR.DATA_DIR)
 
             if sys.platform == "win32":
-                paks_dir = os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(args.executable)), "..", "..", "Content", "Paks"))
+                paks_dir = \
+                    os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(self._config.SPEAR.STANDALONE_EXECUTABLE)), "..", "..", "Content", "Paks"))
             elif sys.platform == "darwin":
-                paks_dir = os.path.realpath(os.path.join(args.executable, "Contents", "UE4", "SpearSim", "Content", "Paks"))
+                paks_dir = \
+                    os.path.realpath(os.path.join(self._config.SPEAR.STANDALONE_EXECUTABLE, "Contents", "UE4", "SpearSim", "Content", "Paks"))
             elif sys.platform == "linux":
-                paks_dir = os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(args.executable)), "SpearSim", "Content", "Paks"))
+                paks_dir = \
+                    os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(self._config.SPEAR.STANDALONE_EXECUTABLE)), "SpearSim", "Content", "Paks"))
             else:
                 assert False
 
@@ -134,7 +138,7 @@ class Env(gym.Env):
                 spear.remove_path(spear_data_dir)
 
             print(f"[SPEAR | env.py] Creating symlink: {spear_data_dir} -> {self._config.SPEAR.DATA_DIR}")
-            os.symlink(args.data_dir, spear_data_dir)
+            os.symlink(self._config.SPEAR.DATA_DIR, spear_data_dir)
 
         # provide additional control over which Vulkan devices are recognized by Unreal
         if len(self._config.SPEAR.VULKAN_DEVICE_FILES) > 0:

--- a/tools/archive_executable.py
+++ b/tools/archive_executable.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
 
     executable_dir    = os.path.realpath(os.path.join(args.input_dir, f"SpearSim-{platform_name}-Shipping"))
     archive_file_name = os.path.realpath(os.path.join(args.output_dir, f"SpearSim-{args.version_tag}-{platform_name}-Shipping"))
-    shutil.make_archive(base_name=archive_file_name, format="zip", root_dir=os.path.join(executable_dir, platform_dir_name), verbose=1)
+    shutil.make_archive(base_name=archive_file_name, format="zip", root_dir=os.path.realpath(os.path.join(executable_dir, platform_dir_name)), verbose=1)
     assert os.path.exists(archive_file_name + ".zip")
 
     print(f"[SPEAR | archive_executable.py] Successfully archived executable to {archive_file_name}.zip")

--- a/tools/build_executable/build_executable.py
+++ b/tools/build_executable/build_executable.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
     unreal_project_dir = os.path.realpath(os.path.join(repo_dir, "cpp", "unreal_projects", "SpearSim"))
     unreal_plugins_dir = os.path.realpath(os.path.join(repo_dir, "cpp", "unreal_plugins"))
     third_party_dir    = os.path.realpath(os.path.join(repo_dir, "third_party"))
-    uproject           = os.path.join(unreal_project_dir, "SpearSim.uproject"),
+    uproject           = os.path.realpath(os.path.join(unreal_project_dir, "SpearSim.uproject"))
     build_config       = "Shipping"
 
     # set various platform-specific variables that we use throughout our build procedure
@@ -152,7 +152,7 @@ if __name__ == "__main__":
     cmd = [
         run_uat_script,
         "BuildCookRun",
-        "-project=" + os.path.join(unreal_project_dir, "SpearSim.uproject"),
+        "-project=" + os.path.realpath(os.path.join(unreal_project_dir, "SpearSim.uproject")),
         "-build",
         "-cook",
         "-stage",

--- a/tools/build_pak_files.py
+++ b/tools/build_pak_files.py
@@ -78,7 +78,7 @@ if __name__ == '__main__':
             os.path.realpath(os.path.join(unreal_project_cooked_dir, "SpearSim", "Content", "Scenes", scene_id)),
         ]
 
-        txt_file = os.path.realpath(os.path.join(output_dir, scene_id + "-" + platform + ".txt"))
+        txt_file = os.path.realpath(os.path.join(output_dir, scene_id + "-" + args.version_tag + "-" + platform + ".txt"))
         pak_file = os.path.realpath(os.path.join(output_dir, scene_id + "-" + args.version_tag + "-" + platform + ".pak"))
 
         perforce_content_scene_dir = os.path.realpath(os.path.join(perforce_content_scenes_dir, scene_id))
@@ -118,7 +118,7 @@ if __name__ == '__main__':
 
         for i, pak_dir in enumerate(pak_dirs):
             with open(txt_file, mode="w" if i==0 else "a") as f:
-                for content_file in glob.glob(os.path.join(pak_dir, "**", "*.*"), recursive=True):
+                for content_file in glob.glob(os.path.realpath(os.path.join(pak_dir, "**", "*.*")), recursive=True):
                     assert content_file.startswith(unreal_project_cooked_dir)
                     content_file = content_file.replace('\\', "/")
                     mount_file = posixpath.join("..", "..", ".." + content_file.split(platform + "NoEditor")[1])

--- a/tools/build_pak_files.py
+++ b/tools/build_pak_files.py
@@ -19,7 +19,7 @@ if __name__ == '__main__':
     parser.add_argument("--perforce_content_dir", required=True)
     parser.add_argument("--output_dir", required=True)
     parser.add_argument("--version_tag", required=True)
-    parser.add_argument("--scene_names")
+    parser.add_argument("--scene_ids")
     args = parser.parse_args()
     
     assert os.path.exists(args.unreal_engine_dir)
@@ -62,30 +62,30 @@ if __name__ == '__main__':
     os.symlink(perforce_content_shared_dir, unreal_project_content_shared_dir)
 
     assert os.path.exists(perforce_content_scenes_dir)
-    scene_names = [ os.path.basename(x) for x in os.listdir(perforce_content_scenes_dir) ]
-    assert len(scene_names) > 0
+    scene_ids = [ os.path.basename(x) for x in os.listdir(perforce_content_scenes_dir) ]
+    assert len(scene_ids) > 0
 
-    if args.scene_names is not None:
-        scene_names = [ s for s in scene_names if fnmatch.fnmatch(s, args.scene_names) ]
+    if args.scene_ids is not None:
+        scene_ids = [ s for s in scene_ids if fnmatch.fnmatch(s, args.scene_ids) ]
 
-    assert len(scene_names) > 0
+    assert len(scene_ids) > 0
 
-    for scene_name in scene_names:
+    for scene_id in scene_ids:
 
         pak_dirs = [
             os.path.realpath(os.path.join(unreal_project_cooked_dir, "Engine", "Content")),
             os.path.realpath(os.path.join(unreal_project_cooked_dir, "SpearSim", "Content", "Shared")),
-            os.path.realpath(os.path.join(unreal_project_cooked_dir, "SpearSim", "Content", "Scenes", scene_name)),
+            os.path.realpath(os.path.join(unreal_project_cooked_dir, "SpearSim", "Content", "Scenes", scene_id)),
         ]
 
-        txt_file = os.path.realpath(os.path.join(output_dir, scene_name + "-" + platform + ".txt"))
-        pak_file = os.path.realpath(os.path.join(output_dir, scene_name + "-" + args.version_tag + "-" + platform + ".pak"))
+        txt_file = os.path.realpath(os.path.join(output_dir, scene_id + "-" + platform + ".txt"))
+        pak_file = os.path.realpath(os.path.join(output_dir, scene_id + "-" + args.version_tag + "-" + platform + ".pak"))
 
-        perforce_content_scene_dir = os.path.realpath(os.path.join(perforce_content_scenes_dir, scene_name))
+        perforce_content_scene_dir = os.path.realpath(os.path.join(perforce_content_scenes_dir, scene_id))
 
         # We do not want to use os.path.realpath(...) here, because that will resolve to the directory inside the user's Perforce workspace.
         # Instead, we want this path to refer to the symlinked version inside the user's unreal project directory.
-        unreal_project_content_scene_dir = os.path.join(unreal_project_content_dir, "Scenes", scene_name)
+        unreal_project_content_scene_dir = os.path.join(unreal_project_content_dir, "Scenes", scene_id)
 
         if spear.path_exists(unreal_project_content_scene_dir):
             print(f"[SPEAR | build_pak_files.py] File or directory or symlink exists, removing: {unreal_project_content_scene_dir}")

--- a/tools/build_third_party_libs.py
+++ b/tools/build_third_party_libs.py
@@ -84,16 +84,14 @@ if __name__ == "__main__":
     if sys.platform == "win32":
 
         cmd = [
-            "bootstrap.bat",
-            "--with-toolset=" + toolset,
-            "--with-libraries=filesystem"
+            "bootstrap.bat"
         ]
         print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
         subprocess.run(cmd, check=True)
 
         cmd = [
             "b2",
-            "toolset=" + c_compiler
+            "headers"
         ]
         print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
         subprocess.run(cmd, check=True)
@@ -101,17 +99,14 @@ if __name__ == "__main__":
     elif sys.platform == "darwin":
 
         cmd = [
-            "./bootstrap.sh",
-            "--with-toolset=" + toolset,
-            "--with-libraries=filesystem"
+            "./bootstrap.sh"
         ]
         print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
         subprocess.run(cmd, check=True)
 
         cmd = [
             "./b2",
-            "toolset=" + c_compiler,
-            'cxxflags="-mmacosx-version-min=10.14"'
+            "headers"
         ]
         print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
         subprocess.run(cmd, check=True)
@@ -119,16 +114,14 @@ if __name__ == "__main__":
     elif sys.platform == "linux":
 
         cmd = [
-            "./bootstrap.sh",
-            "--with-toolset=" + toolset,
-            "--with-libraries=filesystem"
+            "./bootstrap.sh"
         ]
         print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
         subprocess.run(cmd, check=True)
 
         cmd = [
             "./b2",
-            "toolset=" + c_compiler
+            "headers"
         ]
         print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
         subprocess.run(cmd, check=True)

--- a/tools/build_third_party_libs.py
+++ b/tools/build_third_party_libs.py
@@ -52,6 +52,91 @@ if __name__ == "__main__":
         platform_dir = "Linux"
 
     #
+    # Boost
+    #
+
+    print("[SPEAR | build_third_party_libs.py] Building Boost...")
+
+    boost_dir = os.path.realpath(os.path.join(third_party_dir, "boost"))
+    include_dir = os.path.realpath(os.path.join(third_party_dir, "boost", "boost"))
+    build_dir = os.path.realpath(os.path.join(third_party_dir, "boost", "stage"))
+
+    if cxx_compiler.startswith("clang"):
+        toolset = "clang"
+    elif cxx_compiler.startswith("g++"):
+        toolset = "gcc"
+    elif cxx_compiler.startswith("cl"):
+        toolset = "msvc"
+    else:
+        assert False
+
+    if os.path.isdir(include_dir):
+        print(f"[SPEAR | build_third_party_libs.py] Directory exists, removing: {include_dir}")
+        shutil.rmtree(include_dir, ignore_errors=True)
+
+    if os.path.isdir(build_dir):
+        print(f"[SPEAR | build_third_party_libs.py] Directory exists, removing: {include_dir}")
+        shutil.rmtree(include_dir, ignore_errors=True)
+
+    print(f"[SPEAR | build_third_party_libs.py] Creating directory and changing to working: {boost_dir}")
+    os.chdir(boost_dir)
+
+    if sys.platform == "win32":
+
+        cmd = [
+            "bootstrap.bat",
+            "--with-toolset=" + toolset,
+            "--with-libraries=filesystem"
+        ]
+        print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
+        subprocess.run(cmd, check=True)
+
+        cmd = [
+            "b2",
+            "toolset=" + c_compiler
+        ]
+        print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
+        subprocess.run(cmd, check=True)
+
+    elif sys.platform == "darwin":
+
+        cmd = [
+            "./bootstrap.sh",
+            "--with-toolset=" + toolset,
+            "--with-libraries=filesystem"
+        ]
+        print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
+        subprocess.run(cmd, check=True)
+
+        cmd = [
+            "./b2",
+            "toolset=" + c_compiler,
+            'cxxflags="-mmacosx-version-min=10.14"'
+        ]
+        print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
+        subprocess.run(cmd, check=True)
+
+    elif sys.platform == "linux":
+
+        cmd = [
+            "./bootstrap.sh",
+            "--with-toolset=" + toolset,
+            "--with-libraries=filesystem"
+        ]
+        print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
+        subprocess.run(cmd, check=True)
+
+        cmd = [
+            "./b2",
+            "toolset=" + c_compiler
+        ]
+        print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
+        subprocess.run(cmd, check=True)
+
+    else:
+        assert False
+
+    #
     # Eigen
     #
 
@@ -74,8 +159,7 @@ if __name__ == "__main__":
         "-DCMAKE_INSTALL_PREFIX=" + build_dir,
         os.path.join("..", "..")]
     print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
-    cmd_result = subprocess.run(cmd)
-    assert cmd_result.returncode == 0
+    subprocess.run(cmd, check=True)
 
     cmd = [
         "cmake",
@@ -85,8 +169,7 @@ if __name__ == "__main__":
         "install"]
 
     print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
-    cmd_result = subprocess.run(cmd)
-    assert cmd_result.returncode == 0
+    subprocess.run(cmd, check=True)
 
     print("[SPEAR | build_third_party_libs.py] Built Eigen successfully.")
 
@@ -116,8 +199,7 @@ if __name__ == "__main__":
             os.path.join("..", "..")]
 
         print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
-        cmd_result = subprocess.run(cmd)
-        assert cmd_result.returncode == 0
+        subprocess.run(cmd, check=True)
 
         cmd = [
             "cmake",
@@ -139,8 +221,7 @@ if __name__ == "__main__":
             os.path.join("..", "..")]
 
         print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
-        cmd_result = subprocess.run(cmd)
-        assert cmd_result.returncode == 0
+        subprocess.run(cmd, check=True)
 
         cmd = [
             "cmake",
@@ -161,8 +242,7 @@ if __name__ == "__main__":
             os.path.join("..", "..")]
 
         print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
-        cmd_result = subprocess.run(cmd)
-        assert cmd_result.returncode == 0
+        subprocess.run(cmd, check=True)
 
         cmd = [
             "cmake",
@@ -175,8 +255,7 @@ if __name__ == "__main__":
         assert False
 
     print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
-    cmd_result = subprocess.run(cmd)
-    assert cmd_result.returncode == 0
+    subprocess.run(cmd, check=True)
 
     print("[SPEAR | build_third_party_libs.py] Built rpclib successfully.")
 
@@ -205,8 +284,7 @@ if __name__ == "__main__":
             os.path.join("..", "..")]
 
         print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
-        cmd_result = subprocess.run(cmd)
-        assert cmd_result.returncode == 0
+        subprocess.run(cmd, check=True)
 
         cmd = [
             "cmake",
@@ -228,8 +306,7 @@ if __name__ == "__main__":
             os.path.join("..", "..")]
 
         print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
-        cmd_result = subprocess.run(cmd)
-        assert cmd_result.returncode == 0
+        subprocess.run(cmd, check=True)
 
         cmd = [
             "cmake",
@@ -250,8 +327,7 @@ if __name__ == "__main__":
             os.path.join("..", "..")]
 
         print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
-        cmd_result = subprocess.run(cmd)
-        assert cmd_result.returncode == 0
+        subprocess.run(cmd, check=True)
 
         cmd = [
             "cmake",
@@ -264,8 +340,7 @@ if __name__ == "__main__":
         assert False
 
     print(f"[SPEAR | build_third_party_libs.py] Executing: {' '.join(cmd)}")
-    cmd_result = subprocess.run(cmd)
-    assert cmd_result.returncode == 0
+    subprocess.run(cmd, check=True)
 
     print("[SPEAR | build_third_party_libs.py] Built yaml-cpp successfully.")
     print("[SPEAR | build_third_party_libs.py] Done.")

--- a/tools/build_third_party_libs.py
+++ b/tools/build_third_party_libs.py
@@ -57,28 +57,14 @@ if __name__ == "__main__":
 
     print("[SPEAR | build_third_party_libs.py] Building Boost...")
 
-    boost_dir = os.path.realpath(os.path.join(third_party_dir, "boost"))
+    boost_dir   = os.path.realpath(os.path.join(third_party_dir, "boost"))
     include_dir = os.path.realpath(os.path.join(third_party_dir, "boost", "boost"))
-    build_dir = os.path.realpath(os.path.join(third_party_dir, "boost", "stage"))
-
-    if cxx_compiler.startswith("clang"):
-        toolset = "clang"
-    elif cxx_compiler.startswith("g++"):
-        toolset = "gcc"
-    elif cxx_compiler.startswith("cl"):
-        toolset = "msvc"
-    else:
-        assert False
 
     if os.path.isdir(include_dir):
         print(f"[SPEAR | build_third_party_libs.py] Directory exists, removing: {include_dir}")
         shutil.rmtree(include_dir, ignore_errors=True)
 
-    if os.path.isdir(build_dir):
-        print(f"[SPEAR | build_third_party_libs.py] Directory exists, removing: {include_dir}")
-        shutil.rmtree(include_dir, ignore_errors=True)
-
-    print(f"[SPEAR | build_third_party_libs.py] Creating directory and changing to working: {boost_dir}")
+    print(f"[SPEAR | build_third_party_libs.py] Changing directory to working: {boost_dir}")
     os.chdir(boost_dir)
 
     if sys.platform == "win32":

--- a/tools/create_symbolic_links.py
+++ b/tools/create_symbolic_links.py
@@ -28,13 +28,13 @@ if __name__ == "__main__":
     for plugin in unreal_plugins:
 
         # ...if the plugin is a valid plugin (i.e., plugin dir has a uplugin file)
-        uplugin = os.path.join(unreal_plugins_dir, plugin, plugin + ".uplugin")
+        uplugin = os.path.realpath(os.path.join(unreal_plugins_dir, plugin, plugin + ".uplugin"))
         if os.path.exists(uplugin):
 
             print(f"[SPEAR | create_sybmolic_links.py] Found uplugin: {uplugin}")
 
             # create a symlink to third_party
-            symlink_third_party_dir = os.path.join(unreal_plugins_dir, plugin, "ThirdParty")
+            symlink_third_party_dir = os.path.join(unreal_plugins_dir, plugin, "ThirdParty") # don't want os.path.realpath here
             if spear.path_exists(symlink_third_party_dir):
                 print(f"[SPEAR | create_sybmolic_links.py]     File or directory or symlink exists, removing: {symlink_third_party_dir}")
                 spear.remove_path(symlink_third_party_dir)
@@ -44,13 +44,13 @@ if __name__ == "__main__":
 
     assert os.path.exists(unreal_project_dir)
     _, project = os.path.split(unreal_project_dir)
-    uproject = os.path.join(unreal_project_dir, project + ".uproject")
+    uproject = os.path.realpath(os.path.join(unreal_project_dir, project + ".uproject"))
     assert os.path.exists(uproject)
 
     print(f"[SPEAR | create_sybmolic_links.py] Found uproject: {uproject}")
 
     # create a symlink to Engine/Content/StarterContent
-    symlink_starter_content_dir = os.path.join(unreal_project_dir, "Content", "StarterContent")
+    symlink_starter_content_dir = os.path.join(unreal_project_dir, "Content", "StarterContent") # don't want os.path.realpath here
     if spear.path_exists(symlink_starter_content_dir):
         print(f"[SPEAR | create_sybmolic_links.py]     File or directory or symlink exists, removing: {symlink_starter_content_dir}")
         spear.remove_path(symlink_starter_content_dir)
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     os.symlink(starter_content_dir, symlink_starter_content_dir)
 
     # create a symlink to third_party
-    symlink_third_party_dir = os.path.join(unreal_project_dir, "ThirdParty")
+    symlink_third_party_dir = os.path.join(unreal_project_dir, "ThirdParty") # don't want os.path.realpath here
     if spear.path_exists(symlink_third_party_dir):
         print(f"[SPEAR | create_sybmolic_links.py]     File or directory or symlink exists, removing: {symlink_third_party_dir}")
         spear.remove_path(symlink_third_party_dir)
@@ -66,26 +66,25 @@ if __name__ == "__main__":
     os.symlink(third_party_dir, symlink_third_party_dir)
 
     # get list of plugins from the uproject file
-    with open(os.path.join(unreal_project_dir, project + ".uproject")) as f:
+    with open(os.path.realpath(os.path.join(unreal_project_dir, project + ".uproject"))) as f:
         project_plugins = [ p["Name"] for p in json.load(f)["Plugins"] ]
     print(f"[SPEAR | create_sybmolic_links.py]     Plugin dependencies: {project_plugins}")
 
     # create a Plugins dir in the project dir
-    project_plugins_dir = os.path.join(unreal_project_dir, "Plugins")
+    project_plugins_dir = os.path.realpath(os.path.join(unreal_project_dir, "Plugins"))
     os.makedirs(project_plugins_dir, exist_ok=True)
 
     # create symlink for each plugin listed in the project, if the plugin is in our unreal_plugins dir
     for project_plugin in project_plugins:
         if project_plugin in unreal_plugins:
-            plugin_dir = os.path.abspath(os.path.join(unreal_plugins_dir, project_plugin))
-            symlink_plugin_dir = os.path.abspath(os.path.join(project_plugins_dir, project_plugin))
+            plugin_dir = os.path.realpath(os.path.join(unreal_plugins_dir, project_plugin))
+            symlink_plugin_dir = os.path.join(project_plugins_dir, project_plugin) # don't want os.path.realpath here
             if spear.path_exists(symlink_plugin_dir):
                 print(f"[SPEAR | create_sybmolic_links.py]         File or directory or symlink exists, removing: {symlink_plugin_dir}")
                 spear.remove_path(symlink_plugin_dir)
             print(f"[SPEAR | create_sybmolic_links.py]         Creating symlink: {symlink_plugin_dir} -> {plugin_dir}")
             os.symlink(plugin_dir, symlink_plugin_dir)
         else:
-            print(f"[SPEAR | create_sybmolic_links.py]         {project} depends on {project_plugin}, but this plugin is not in {unreal_plugins_dir}, so we do not create a symlink...")
+            print(f"[SPEAR | create_sybmolic_links.py]         {project} depends on {project_plugin}, but this plugin is not in {unreal_plugins_dir}, so we do not attempt to create a symlink...")
 
     print("[SPEAR | create_sybmolic_links.py] Done.")
- 

--- a/tools/run_executable.py
+++ b/tools/run_executable.py
@@ -1,0 +1,132 @@
+#
+# Copyright(c) 2022 Intel. Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+#
+
+import argparse
+import os
+import spear
+import subprocess
+import sys
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--executable", required=True)
+    parser.add_argument("--temp_dir", default=os.path.realpath(os.path.join(os.path.dirname(__file__), "tmp")))
+    parser.add_argument("--data_dir")
+    parser.add_argument("--scene_id")
+    parser.add_argument("--map_id")
+    args = parser.parse_args()
+    
+    assert os.path.exists(args.executable)
+
+    # determine the internal executable we will actually launch
+    executable_name, executable_ext = os.path.splitext(args.executable)
+
+    if sys.platform == "win32":
+        assert executable_name[-4:] == "-Cmd"
+        assert executable_ext == ".exe"
+        executable_internal = executable
+    elif sys.platform == "darwin":
+        assert executable_ext == ".app"
+        executable_internal = os.path.realpath(os.path.join(args.executable, "Contents", "MacOS", os.path.basename(executable_name)))
+    elif sys.platform == "linux":
+        assert launch_executable_ext == ".sh"
+        executable_internal = launch_executable
+    else:
+        assert False
+
+    assert os.path.exists(executable_internal)
+
+    # load config
+    config = spear.get_config(user_config_files=[])
+    config.defrost()
+    config.SIMULATION_CONTROLLER.INTERACTION_MODE = "interactive"
+    if args.scene_id is not None:
+        config.SIMULATION_CONTROLLER.SCENE_ID = args.scene_id
+    if args.map_id is not None:
+        config.SIMULATION_CONTROLLER.MAP_ID = args.map_id
+    config.freeze()
+
+    # write temp file
+    temp_dir = os.path.realpath(args.temp_dir)
+    temp_config_file = os.path.realpath(os.path.join(temp_dir, "config.yaml"))
+
+    print("[SPEAR | run_executable.py] Writing temp config file: " + temp_config_file)
+
+    if not os.path.exists(temp_dir):
+        os.makedirs(temp_dir)
+    with open(temp_config_file, "w") as output:
+        config.dump(stream=output, default_flow_style=False)
+
+    # create a symlink to data_dir
+    if args.data_dir is not None:
+
+        assert os.path.exists(args.data_dir)
+
+        if sys.platform == "win32":
+            paks_dir = os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(args.executable)), "..", "..", "Content", "Paks"))
+        elif sys.platform == "darwin":
+            paks_dir = os.path.realpath(os.path.join(args.executable, "Contents", "UE4", "SpearSim", "Content", "Paks"))
+        elif sys.platform == "linux":
+            paks_dir = os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(args.executable)), "SpearSim", "Content", "Paks"))
+        else:
+            assert False
+
+        assert os.path.exists(paks_dir)
+
+        # we don't use os.path.realpath here because we don't want to resolve the symlink
+        spear_data_dir = os.path.join(paks_dir, "SpearData")
+
+        if spear.path_exists(spear_data_dir):
+            print(f"[SPEAR | run_executable.py] File or directory or symlink exists, removing: {spear_data_dir}")
+            spear.remove_path(spear_data_dir)
+
+        print(f"[SPEAR | run_executable.py] Creating symlink: {spear_data_dir} -> {args.data_dir}")
+        os.symlink(args.data_dir, spear_data_dir)
+
+    # provide additional control over which Vulkan devices are recognized by Unreal
+    if len(config.SPEAR.VULKAN_DEVICE_FILES) > 0:
+        print("[SPEAR | run_executable.py] Setting VK_ICD_FILENAMES environment variable: " + config.SPEAR.VULKAN_DEVICE_FILES)
+        os.environ["VK_ICD_FILENAMES"] = config.SPEAR.VULKAN_DEVICE_FILES
+
+    # set up launch executable and command-line arguments
+    launch_args = []
+
+    launch_args.append("-game")
+    launch_args.append("-windowed")
+    launch_args.append("-novsync")
+    launch_args.append("-nosound")
+    launch_args.append("-notexturestreaming")
+    launch_args.append("-resx={}".format(config.SPEAR.WINDOW_RESOLUTION_X))
+    launch_args.append("-resy={}".format(config.SPEAR.WINDOW_RESOLUTION_Y))
+    launch_args.append("-graphicsadapter={}".format(config.SPEAR.GPU_ID))
+
+    if len(config.SPEAR.UNREAL_INTERNAL_LOG_FILE) > 0:
+        launch_args.append("-log={}".format(config.SPEAR.UNREAL_INTERNAL_LOG_FILE))
+   
+    # on Windows, we need to pass in extra command-line parameters to enable DirectX 12
+    # and so that calls to UE_Log and writes to std::cout are visible on the command-line
+    if sys.platform == "win32":
+        launch_args.append("-dx12")            
+        launch_args.append("-stdout")
+        launch_args.append("-fullstdoutlogoutput")
+
+    launch_args.append("-config_file={}".format(temp_config_file))
+
+    for a in config.SPEAR.CUSTOM_COMMAND_LINE_ARGUMENTS:
+        launch_args.append("{}".format(a))
+
+    # launch executable
+    cmd = [executable_internal] + launch_args
+
+    print("[SPEAR | run_executable.py] Launching executable with the following command-line arguments:")
+    print(" ".join(cmd))
+
+    print("[SPEAR | run_executable.py] Launching executable with the following config values:")
+    print(config)
+
+    subprocess.run(cmd, check=True)
+    
+    print("[SPEAR | run_executable.py] Done.")

--- a/tools/run_executable.py
+++ b/tools/run_executable.py
@@ -27,13 +27,13 @@ if __name__ == '__main__':
     if sys.platform == "win32":
         assert executable_name[-4:] == "-Cmd"
         assert executable_ext == ".exe"
-        executable_internal = executable
+        executable_internal = os.path.realpath(args.executable)
     elif sys.platform == "darwin":
         assert executable_ext == ".app"
         executable_internal = os.path.realpath(os.path.join(args.executable, "Contents", "MacOS", os.path.basename(executable_name)))
     elif sys.platform == "linux":
-        assert launch_executable_ext == ".sh"
-        executable_internal = launch_executable
+        assert executable_ext == ".sh"
+        executable_internal = os.path.realpath(args.executable)
     else:
         assert False
 

--- a/tools/sign_executable/sign_executable.py
+++ b/tools/sign_executable/sign_executable.py
@@ -40,11 +40,11 @@ if __name__ == "__main__":
     assert os.path.exists(executable)
 
     if not args.request_uuid:
-        radio_effect_unit_component = os.path.join(executable, "Contents", "Resources", "RadioEffectUnit.component")
+        radio_effect_unit_component = os.path.realpath(os.path.join(executable, "Contents", "Resources", "RadioEffectUnit.component"))
         print(f"[SPEAR | sign_executable.py] Removing {radio_effect_unit_component}")
         shutil.rmtree(radio_effect_unit_component, ignore_errors=True)
         
-        radio_effect_unit = os.path.join(executable, "Contents", "UE4", "Engine", "Build", "Mac", "RadioEffectUnit")
+        radio_effect_unit = os.path.realpath(os.path.join(executable, "Contents", "UE4", "Engine", "Build", "Mac", "RadioEffectUnit"))
         print(f"[SPEAR | sign_executable.py] Removing {radio_effect_unit}")
         shutil.rmtree(radio_effect_unit, ignore_errors=True)
 
@@ -102,18 +102,19 @@ if __name__ == "__main__":
 
         # files that need to be code-signed
         sign_files = [
-            os.path.join(executable, "Contents", "UE4", "Engine", "Binaries", "ThirdParty", "Ogg", "Mac", "libogg.dylib"),
-            os.path.join(executable, "Contents", "UE4", "Engine", "Binaries", "ThirdParty", "Vorbis", "Mac", "libvorbis.dylib"),
-            os.path.join(executable, "Contents", "UE4", "Engine", "Binaries", "ThirdParty", "PhysX3", "Mac", "libPhysX3.dylib"),
-            os.path.join(executable, "Contents", "UE4", "Engine", "Binaries", "ThirdParty", "PhysX3", "Mac", "libPhysX3Common.dylib"),
-            os.path.join(executable, "Contents", "UE4", "Engine", "Binaries", "ThirdParty", "PhysX3", "Mac", "libPxFoundation.dylib"),
-            os.path.join(executable, "Contents", "UE4", "Engine", "Binaries", "ThirdParty", "PhysX3", "Mac", "libAPEX_Clothing.dylib"),
-            os.path.join(executable, "Contents", "UE4", "Engine", "Binaries", "ThirdParty", "PhysX3", "Mac", "libPxPvdSDK.dylib"),
-            os.path.join(executable, "Contents", "UE4", "Engine", "Binaries", "ThirdParty", "PhysX3", "Mac", "libNvCloth.dylib"),
-            os.path.join(executable, "Contents", "UE4", "Engine", "Binaries", "ThirdParty", "PhysX3", "Mac", "libPhysX3Cooking.dylib"),
-            os.path.join(executable, "Contents", "UE4", "Engine", "Binaries", "ThirdParty", "PhysX3", "Mac", "libAPEX_Legacy.dylib"),
-            os.path.join(executable, "Contents", "UE4", "Engine", "Binaries", "ThirdParty", "PhysX3", "Mac", "libApexFramework.dylib"),
-            os.path.join(executable, "Contents", "MacOS", os.path.splitext(executable_name)[0])]
+            os.path.realpath(os.path.join(executable, "Contents", "UE4", "Engine", "Binaries", "ThirdParty", "Ogg", "Mac", "libogg.dylib")),
+            os.path.realpath(os.path.join(executable, "Contents", "UE4", "Engine", "Binaries", "ThirdParty", "Vorbis", "Mac", "libvorbis.dylib")),
+            os.path.realpath(os.path.join(executable, "Contents", "UE4", "Engine", "Binaries", "ThirdParty", "PhysX3", "Mac", "libPhysX3.dylib")),
+            os.path.realpath(os.path.join(executable, "Contents", "UE4", "Engine", "Binaries", "ThirdParty", "PhysX3", "Mac", "libPhysX3Common.dylib")),
+            os.path.realpath(os.path.join(executable, "Contents", "UE4", "Engine", "Binaries", "ThirdParty", "PhysX3", "Mac", "libPxFoundation.dylib")),
+            os.path.realpath(os.path.join(executable, "Contents", "UE4", "Engine", "Binaries", "ThirdParty", "PhysX3", "Mac", "libAPEX_Clothing.dylib")),
+            os.path.realpath(os.path.join(executable, "Contents", "UE4", "Engine", "Binaries", "ThirdParty", "PhysX3", "Mac", "libPxPvdSDK.dylib")),
+            os.path.realpath(os.path.join(executable, "Contents", "UE4", "Engine", "Binaries", "ThirdParty", "PhysX3", "Mac", "libNvCloth.dylib")),
+            os.path.realpath(os.path.join(executable, "Contents", "UE4", "Engine", "Binaries", "ThirdParty", "PhysX3", "Mac", "libPhysX3Cooking.dylib")),
+            os.path.realpath(os.path.join(executable, "Contents", "UE4", "Engine", "Binaries", "ThirdParty", "PhysX3", "Mac", "libAPEX_Legacy.dylib")),
+            os.path.realpath(os.path.join(executable, "Contents", "UE4", "Engine", "Binaries", "ThirdParty", "PhysX3", "Mac", "libApexFramework.dylib")),
+            os.path.realpath(os.path.join(executable, "Contents", "MacOS", os.path.splitext(executable_name)[0]))
+        ]
 
         assert os.path.exists(args.entitlements_file)
 
@@ -127,7 +128,7 @@ if __name__ == "__main__":
         os.makedirs(args.temp_dir, exist_ok=True)
 
         # create a zip file for notarization
-        notarization_zip = os.path.join(args.temp_dir, f"{os.path.splitext(executable_name)[0]}.zip")
+        notarization_zip = os.path.realpath(os.path.join(args.temp_dir, f"{os.path.splitext(executable_name)[0]}.zip"))
         cmd = ["ditto", "-c", "-k", "--rsrc", "--keepParent", executable, notarization_zip]
         print(f"[SPEAR | sign_executable.py] Executing: {' '.join(cmd)}")
         subprocess.run(cmd, check=True)


### PR DESCRIPTION
- implemented `tools/run_executable.py`, which can be used to launch a shipping executable, load a scene specified on the command-line, and let the user navigate around the scene interactively using the keyboard
- this functionality needed to be implemented in a standalone Python tool because it must create a symlink from the `Contents` directory of the executable to a user's local pak directory, and this must be done prior to launching the executable
- it is also not possible to specify a map on the command-line for shipping builds (without rebuilding the engine with a specific preprocessor macro defined), so we need some kind of wrapper around a shipping executable that enables loading a specific map via the command-line
- improved configuration options for loading a specific scene; now the user specifies `SIMULATION_CONTROLLER.SCENE_ID` and optionally `SIMULATION_CONTROLLER.MAP_ID`, which will load `/Game/Scenes/SCENE_ID/Maps/MAP_ID.MAP_ID`; if `MAP_ID` is blank, it defaults to the same value as `SCENE_ID`
- made the use of `os.path.realpath` more consistent and more readable throughout the codebase
- removed the `SPEAR.CONTENT_DIR` configuration option because it can be inferred automatically from the executable path
- added a build step for boost that simplifies how we include boost packages in our `Build.cs` files, and will be required if we ever want to use a boost package that is not header-only (e.g., `boost::filesystem`)