### PR TITLE
tool for creating and removing symlinks to a specific scene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,9 @@ cpp/unreal_plugins/*/ThirdParty
 cpp/unreal_projects/SpearSim/Binaries
 cpp/unreal_projects/SpearSim/Build
 cpp/unreal_projects/SpearSim/CMakeLists.txt
-cpp/unreal_projects/SpearSim/Content/Maps
-cpp/unreal_projects/SpearSim/Content/Scene
+cpp/unreal_projects/SpearSim/Content/Scenes/kujiale_*
+cpp/unreal_projects/SpearSim/Content/Scenes/warehouse_*
+cpp/unreal_projects/SpearSim/Content/Shared
 cpp/unreal_projects/SpearSim/Content/StarterContent
 cpp/unreal_projects/SpearSim/DerivedDataCache
 cpp/unreal_projects/SpearSim/Intermediate
@@ -58,5 +59,4 @@ examples/open_loop_control_fetch/user_config.yaml
 
 python/spear_sim.egg-info
 
-tools/sign_executable/tmp
 tools/tmp

--- a/tools/build_pak_files.py
+++ b/tools/build_pak_files.py
@@ -55,7 +55,7 @@ if __name__ == '__main__':
     unreal_project_cooked_dir = os.path.realpath(os.path.join(unreal_project_dir, "Saved", "Cooked", platform + "NoEditor"))
 
     if spear.path_exists(unreal_project_content_shared_dir):
-        print(f"[SPEAR | build_pak_files.py] Removing file or directory or symlink: {unreal_project_content_shared_dir}")
+        print(f"[SPEAR | build_pak_files.py] File or directory or symlink exists, removing: {unreal_project_content_shared_dir}")
         spear.remove_path(unreal_project_content_shared_dir)
 
     print(f"[SPEAR | build_pak_files.py] Creating symlink: {unreal_project_content_shared_dir} -> {perforce_content_shared_dir}")

--- a/tools/prepare_scene_for_editing.py
+++ b/tools/prepare_scene_for_editing.py
@@ -40,7 +40,6 @@ if __name__ == '__main__':
         os.symlink(perforce_content_shared_dir, unreal_project_content_shared_dir)
 
     # Create and/or remove symlink for scene directory
-
     perforce_content_scene_dir = os.path.realpath(os.path.join(args.perforce_content_dir, "Scenes", args.scene_id))
 
     # We do not want to use os.path.realpath(...) here, because that will resolve to the directory inside the user's Perforce workspace.

--- a/tools/prepare_scene_for_editing.py
+++ b/tools/prepare_scene_for_editing.py
@@ -1,0 +1,60 @@
+#
+# Copyright(c) 2022 Intel. Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+#
+
+import argparse
+import fnmatch
+import glob
+import os
+import posixpath
+import spear
+import subprocess
+import sys
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--perforce_content_dir", required=True)
+    parser.add_argument("--scene_id", required=True)
+    parser.add_argument("--remove_symlink", action="store_true")
+    args = parser.parse_args()
+    
+    assert os.path.exists(args.perforce_content_dir)
+
+    unreal_project_content_dir = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "cpp", "unreal_projects", "SpearSim", "Content"))
+
+    # Create and/or remove symlink for Shared directory
+    perforce_content_shared_dir = os.path.realpath(os.path.join(args.perforce_content_dir, "Shared"))
+
+    # We do not want to use os.path.realpath(...) here, because that will resolve to the directory inside the user's Perforce workspace.
+    # Instead, we want this path to refer to the symlinked version inside the user's unreal project directory.
+    unreal_project_content_shared_dir = os.path.join(unreal_project_content_dir, "Shared")
+
+    if spear.path_exists(unreal_project_content_shared_dir):
+        print(f"[SPEAR | prepare_scene_for_editing.py] File or directory or symlink exists, removing: {unreal_project_content_shared_dir}")
+        spear.remove_path(unreal_project_content_shared_dir)
+
+    if not args.remove_symlink:
+        print(f"[SPEAR | prepare_scene_for_editing.py] Creating symlink: {unreal_project_content_shared_dir} -> {perforce_content_shared_dir}")
+        os.symlink(perforce_content_shared_dir, unreal_project_content_shared_dir)
+
+    # Create and/or remove symlink for scene directory
+
+    perforce_content_scene_dir = os.path.realpath(os.path.join(args.perforce_content_dir, "Scenes", args.scene_id))
+
+    # We do not want to use os.path.realpath(...) here, because that will resolve to the directory inside the user's Perforce workspace.
+    # Instead, we want this path to refer to the symlinked version inside the user's unreal project directory.
+    unreal_project_content_scene_dir = os.path.join(unreal_project_content_dir, "Scenes", args.scene_id)
+
+    assert os.path.exists(perforce_content_scene_dir)
+
+    if spear.path_exists(unreal_project_content_scene_dir):
+        print(f"[SPEAR | prepare_scene_for_editing.py] File or directory or symlink exists, removing: {unreal_project_content_scene_dir}")
+        spear.remove_path(unreal_project_content_scene_dir)
+
+    if not args.remove_symlink:
+        print(f"[SPEAR | prepare_scene_for_editing.py] Creating symlink: {unreal_project_content_scene_dir} -> {perforce_content_scene_dir}")
+        os.symlink(perforce_content_scene_dir, unreal_project_content_scene_dir)
+
+    print("[SPEAR | prepare_scene_for_editing.py] Done.")

--- a/tools/prepare_scene_for_editing.py
+++ b/tools/prepare_scene_for_editing.py
@@ -3,13 +3,8 @@
 #
 
 import argparse
-import fnmatch
-import glob
 import os
-import posixpath
 import spear
-import subprocess
-import sys
 
 
 if __name__ == '__main__':

--- a/tools/prepare_scene_for_editing.py
+++ b/tools/prepare_scene_for_editing.py
@@ -21,6 +21,7 @@ if __name__ == '__main__':
 
     # Create and/or remove symlink for Shared directory
     perforce_content_shared_dir = os.path.realpath(os.path.join(args.perforce_content_dir, "Shared"))
+    assert os.path.exists(perforce_content_shared_dir)
 
     # We do not want to use os.path.realpath(...) here, because that will resolve to the directory inside the user's Perforce workspace.
     # Instead, we want this path to refer to the symlinked version inside the user's unreal project directory.
@@ -36,12 +37,11 @@ if __name__ == '__main__':
 
     # Create and/or remove symlink for scene directory
     perforce_content_scene_dir = os.path.realpath(os.path.join(args.perforce_content_dir, "Scenes", args.scene_id))
+    assert os.path.exists(perforce_content_scene_dir)
 
     # We do not want to use os.path.realpath(...) here, because that will resolve to the directory inside the user's Perforce workspace.
     # Instead, we want this path to refer to the symlinked version inside the user's unreal project directory.
     unreal_project_content_scene_dir = os.path.join(unreal_project_content_dir, "Scenes", args.scene_id)
-
-    assert os.path.exists(perforce_content_scene_dir)
 
     if spear.path_exists(unreal_project_content_scene_dir):
         print(f"[SPEAR | prepare_scene_for_editing.py] File or directory or symlink exists, removing: {unreal_project_content_scene_dir}")

--- a/tools/prepare_scene_for_editing.py
+++ b/tools/prepare_scene_for_editing.py
@@ -12,7 +12,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("--perforce_content_dir", required=True)
     parser.add_argument("--scene_id", required=True)
-    parser.add_argument("--remove_symlink", action="store_true")
+    parser.add_argument("--remove_symlinks", action="store_true")
     args = parser.parse_args()
     
     assert os.path.exists(args.perforce_content_dir)
@@ -31,7 +31,7 @@ if __name__ == '__main__':
         print(f"[SPEAR | prepare_scene_for_editing.py] File or directory or symlink exists, removing: {unreal_project_content_shared_dir}")
         spear.remove_path(unreal_project_content_shared_dir)
 
-    if not args.remove_symlink:
+    if not args.remove_symlinks:
         print(f"[SPEAR | prepare_scene_for_editing.py] Creating symlink: {unreal_project_content_shared_dir} -> {perforce_content_shared_dir}")
         os.symlink(perforce_content_shared_dir, unreal_project_content_shared_dir)
 
@@ -47,7 +47,7 @@ if __name__ == '__main__':
         print(f"[SPEAR | prepare_scene_for_editing.py] File or directory or symlink exists, removing: {unreal_project_content_scene_dir}")
         spear.remove_path(unreal_project_content_scene_dir)
 
-    if not args.remove_symlink:
+    if not args.remove_symlinks:
         print(f"[SPEAR | prepare_scene_for_editing.py] Creating symlink: {unreal_project_content_scene_dir} -> {perforce_content_scene_dir}")
         os.symlink(perforce_content_scene_dir, unreal_project_content_scene_dir)
 

--- a/tools/run_executable.py
+++ b/tools/run_executable.py
@@ -14,7 +14,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("--executable", required=True)
     parser.add_argument("--temp_dir", default=os.path.realpath(os.path.join(os.path.dirname(__file__), "tmp")))
-    parser.add_argument("--data_dir")
+    parser.add_argument("--paks_dir")
     parser.add_argument("--scene_id")
     parser.add_argument("--map_id")
     args = parser.parse_args()
@@ -60,10 +60,10 @@ if __name__ == '__main__':
     with open(temp_config_file, "w") as output:
         config.dump(stream=output, default_flow_style=False)
 
-    # create a symlink to data_dir
-    if args.data_dir is not None:
+    # create a symlink to paks_dir
+    if args.paks_dir is not None:
 
-        assert os.path.exists(args.data_dir)
+        assert os.path.exists(args.paks_dir)
 
         if sys.platform == "win32":
             paks_dir = os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(args.executable)), "..", "..", "Content", "Paks"))
@@ -83,8 +83,8 @@ if __name__ == '__main__':
             print(f"[SPEAR | run_executable.py] File or directory or symlink exists, removing: {spear_data_dir}")
             spear.remove_path(spear_data_dir)
 
-        print(f"[SPEAR | run_executable.py] Creating symlink: {spear_data_dir} -> {args.data_dir}")
-        os.symlink(args.data_dir, spear_data_dir)
+        print(f"[SPEAR | run_executable.py] Creating symlink: {spear_data_dir} -> {args.paks_dir}")
+        os.symlink(args.paks_dir, spear_data_dir)
 
     # provide additional control over which Vulkan devices are recognized by Unreal
     if len(config.SPEAR.VULKAN_DEVICE_FILES) > 0:


### PR DESCRIPTION
this tool enables editing scenes in the Unreal Editor, via SpearSim.uproject, without needing to copy folders back and forth from the user's local Perforce workspace