### PR TITLE
Fix pak build issue on Linux + improve `build_pak_files.py`

### DIFF
--- a/cpp/unreal_projects/SpearSim/Config/Linux/LinuxEngine.ini
+++ b/cpp/unreal_projects/SpearSim/Config/Linux/LinuxEngine.ini
@@ -6,7 +6,6 @@
 
 [/Script/Engine.RendererSettings]
 r.RayTracing=False
-r.ReflectionCaptureResolution=1024
 r.SSGI.Enable=True
 r.GenerateMeshDistanceFields=True
 r.DistanceFieldBuild.Compress=True

--- a/cpp/unreal_projects/SpearSim/Config/Mac/MacEngine.ini
+++ b/cpp/unreal_projects/SpearSim/Config/Mac/MacEngine.ini
@@ -6,7 +6,6 @@
 
 [/Script/Engine.RendererSettings]
 r.RayTracing=False
-r.ReflectionCaptureResolution=1024
 r.SSGI.Enable=True
 r.GenerateMeshDistanceFields=True
 r.DistanceFieldBuild.Compress=True

--- a/tools/build_executable/LinuxEngine.ini
+++ b/tools/build_executable/LinuxEngine.ini
@@ -13,7 +13,6 @@
 
 [/Script/Engine.RendererSettings]
 r.RayTracing=False
-r.ReflectionCaptureResolution=1024
 r.SSGI.Enable=True
 r.GenerateMeshDistanceFields=True
 r.DistanceFieldBuild.Compress=True

--- a/tools/build_executable/MacEngine.ini
+++ b/tools/build_executable/MacEngine.ini
@@ -13,7 +13,6 @@
 
 [/Script/Engine.RendererSettings]
 r.RayTracing=False
-r.ReflectionCaptureResolution=1024
 r.SSGI.Enable=True
 r.GenerateMeshDistanceFields=True
 r.DistanceFieldBuild.Compress=True

--- a/tools/build_pak_files.py
+++ b/tools/build_pak_files.py
@@ -23,12 +23,15 @@ if __name__ == '__main__':
     parser.add_argument("--scene_ids")
     args = parser.parse_args()
     
+    assert os.path.exists(args.unreal_engine_dir)
+
     unreal_project_dir          = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "cpp", "unreal_projects", "SpearSim"))
     uproject                    = os.path.realpath(os.path.join(unreal_project_dir, "SpearSim.uproject"))
     unreal_project_content_dir  = os.path.realpath(os.path.join(unreal_project_dir, "Content"))
     output_dir                  = os.path.realpath(args.output_dir)
 
-    assert os.path.exists(args.unreal_engine_dir)
+    # create the output_dir
+    os.makedirs(output_dir, exist_ok=True)
 
     if sys.platform == "win32":
         platform          = "Windows"
@@ -51,7 +54,6 @@ if __name__ == '__main__':
     # once we know the platform, set our cooked dir
     unreal_project_cooked_dir = os.path.realpath(os.path.join(unreal_project_dir, "Saved", "Cooked", platform + "NoEditor"))
 
-    # delete existing contents and create symlinks to perforce content directory
     if args.create_symlinks:
         assert os.path.exists(args.perforce_content_dir)
 
@@ -69,32 +71,17 @@ if __name__ == '__main__':
         print(f"[SPEAR | build_pak_files.py] Creating symlink: {unreal_project_content_shared_dir} -> {perforce_content_shared_dir}")
         os.symlink(perforce_content_shared_dir, unreal_project_content_shared_dir)
 
-    # We do not want to use os.path.realpath(...) here, because that will resolve to the directory inside the user's Perforce workspace.
-    # Instead, we want this path to refer to the symlinked version inside the user's unreal project directory.
-    unreal_project_content_scenes_dir = os.path.join(unreal_project_content_dir, "Scenes")
+        assert os.path.exists(perforce_content_scenes_dir)
+        scene_ids = [ os.path.basename(x) for x in os.listdir(perforce_content_scenes_dir) ]
+        assert len(scene_ids) > 0
 
-    assert os.path.exists(unreal_project_content_scenes_dir)
-    scene_ids = [ os.path.basename(x) for x in os.listdir(unreal_project_content_scenes_dir) ]
-    scene_ids.remove("starter_content_0000")    # no need to build pak file for starter_content_0000 as it is built with the executable
-    assert len(scene_ids) > 0
+        if args.scene_ids is not None:
+            scene_ids = [ s for s in scene_ids if fnmatch.fnmatch(s, args.scene_ids) ]
 
-    if args.scene_ids is not None:
-        scene_ids = [ s for s in scene_ids if fnmatch.fnmatch(s, args.scene_ids) ]
+        assert len(scene_ids) > 0
 
-    assert len(scene_ids) > 0
+        for scene_id in scene_ids:
 
-    for scene_id in scene_ids:
-
-        pak_dirs = [
-            os.path.realpath(os.path.join(unreal_project_cooked_dir, "Engine", "Content")),
-            os.path.realpath(os.path.join(unreal_project_cooked_dir, "SpearSim", "Content", "Shared")),
-            os.path.realpath(os.path.join(unreal_project_cooked_dir, "SpearSim", "Content", "Scenes", scene_id)),
-        ]
-
-        txt_file = os.path.realpath(os.path.join(output_dir, scene_id + "-" + args.version_tag + "-" + platform + ".txt"))
-        pak_file = os.path.realpath(os.path.join(output_dir, scene_id + "-" + args.version_tag + "-" + platform + ".pak"))
-
-        if args.create_symlinks:
             perforce_content_scene_dir = os.path.realpath(os.path.join(perforce_content_scenes_dir, scene_id))
 
             # We do not want to use os.path.realpath(...) here, because that will resolve to the directory inside the user's Perforce workspace.
@@ -108,6 +95,65 @@ if __name__ == '__main__':
             print(f"[SPEAR | build_pak_files.py] Creating symlink: {unreal_project_content_scene_dir} -> {perforce_content_scene_dir}")
             os.symlink(perforce_content_scene_dir, unreal_project_content_scene_dir)
 
+            # see https://docs.unrealengine.com/4.26/en-US/SharingAndReleasing/Deployment/Cooking for more information on these parameters
+            cmd = [
+                unreal_editor_bin,
+                uproject,
+                "-run=Cook",
+                "-targetplatform=" + platform + "NoEditor",
+                "-fileopenlog",
+                "-ddc=InstalledDerivedDataBackendGraph",
+                "-unversioned",
+                "-stdout",
+                "-fullstdoutlogoutput",
+                "-crashforuat",
+                "-unattended",
+                "-nologtimes",
+                "-utf8output"
+            ]
+            print(f"[SPEAR | build_pak_files.py] Executing: {' '.join(cmd)}")
+            subprocess.run(cmd, check=True)
+
+            pak_dirs = [
+                os.path.realpath(os.path.join(unreal_project_cooked_dir, "Engine", "Content")),
+                os.path.realpath(os.path.join(unreal_project_cooked_dir, "SpearSim", "Content", "Shared")),
+                os.path.realpath(os.path.join(unreal_project_cooked_dir, "SpearSim", "Content", "Scenes", scene_id)),
+            ]
+
+            txt_file = os.path.realpath(os.path.join(output_dir, scene_id + "-" + args.version_tag + "-" + platform + ".txt"))
+            pak_file = os.path.realpath(os.path.join(output_dir, scene_id + "-" + args.version_tag + "-" + platform + ".pak"))
+
+            for i, pak_dir in enumerate(pak_dirs):
+                with open(txt_file, mode="w" if i==0 else "a") as f:
+                    for content_file in glob.glob(os.path.realpath(os.path.join(pak_dir, "**", "*.*")), recursive=True):
+                        assert content_file.startswith(unreal_project_cooked_dir)
+                        content_file = content_file.replace('\\', "/")
+                        mount_file = posixpath.join("..", "..", ".." + content_file.split(platform + "NoEditor")[1])
+                        f.write(f'"{content_file}" "{mount_file}" "" \n')
+
+            # construct command to generate the final pak file
+            cmd = [
+                unreal_pak_bin,
+                pak_file,
+                "-create=" + txt_file,
+                "-platform=" + platform,
+                "-multiprocess",
+                "-compress"
+            ]
+            print(f"[SPEAR | build_pak_files.py] Executing: {' '.join(cmd)}")
+            subprocess.run(cmd, check=True)
+
+            assert os.path.exists(pak_file)
+            print(f"[SPEAR | build_pak_files.py] Successfully built {pak_file}")
+
+            print(f"[SPEAR | build_pak_files.py] Removing symlink: {unreal_project_content_scene_dir}")
+            spear.remove_path(unreal_project_content_scene_dir)
+
+        print(f"[SPEAR | build_pak_files.py] Removing symlink: {unreal_project_content_shared_dir}")
+        spear.remove_path(unreal_project_content_shared_dir)
+
+        print("[SPEAR | build_pak_files.py] Done.")
+    else:
         # see https://docs.unrealengine.com/4.26/en-US/SharingAndReleasing/Deployment/Cooking for more information on these parameters
         cmd = [
             unreal_editor_bin,
@@ -126,37 +172,3 @@ if __name__ == '__main__':
         ]
         print(f"[SPEAR | build_pak_files.py] Executing: {' '.join(cmd)}")
         subprocess.run(cmd, check=True)
-
-        # create the output_dir
-        os.makedirs(output_dir, exist_ok=True)
-
-        for i, pak_dir in enumerate(pak_dirs):
-            with open(txt_file, mode="w" if i==0 else "a") as f:
-                for content_file in glob.glob(os.path.realpath(os.path.join(pak_dir, "**", "*.*")), recursive=True):
-                    assert content_file.startswith(unreal_project_cooked_dir)
-                    content_file = content_file.replace('\\', "/")
-                    mount_file = posixpath.join("..", "..", ".." + content_file.split(platform + "NoEditor")[1])
-                    f.write(f'"{content_file}" "{mount_file}" "" \n')
-
-        # construct command to generate the final pak file
-        cmd = [
-            unreal_pak_bin,
-            pak_file,
-            "-create=" + txt_file,
-            "-platform=" + platform,
-            "-multiprocess",
-            "-compress"
-        ]
-        print(f"[SPEAR | build_pak_files.py] Executing: {' '.join(cmd)}")
-        subprocess.run(cmd, check=True)
-
-        assert os.path.exists(pak_file)
-        print(f"[SPEAR | build_pak_files.py] Successfully built {pak_file}")
-
-        print(f"[SPEAR | build_pak_files.py] Removing symlink: {unreal_project_content_scene_dir}")
-        spear.remove_path(unreal_project_content_scene_dir)
-
-    print(f"[SPEAR | build_pak_files.py] Removing symlink: {unreal_project_content_shared_dir}")
-    spear.remove_path(unreal_project_content_shared_dir)
-
-    print("[SPEAR | build_pak_files.py] Done.")

--- a/tools/build_pak_files.py
+++ b/tools/build_pak_files.py
@@ -15,23 +15,20 @@ import sys
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--unreal_engine_dir", required=True)
+    parser.add_argument("--unreal_engine_dir", required=True)    
     parser.add_argument("--output_dir", required=True)
     parser.add_argument("--version_tag", required=True)
-    parser.add_argument("--create_symlinks", action="store_true")
+    parser.add_argument("--skip_create_symlinks", action="store_true")
     parser.add_argument("--perforce_content_dir")
     parser.add_argument("--scene_ids")
     args = parser.parse_args()
-    
-    assert os.path.exists(args.unreal_engine_dir)
 
     unreal_project_dir          = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "cpp", "unreal_projects", "SpearSim"))
     uproject                    = os.path.realpath(os.path.join(unreal_project_dir, "SpearSim.uproject"))
     unreal_project_content_dir  = os.path.realpath(os.path.join(unreal_project_dir, "Content"))
     output_dir                  = os.path.realpath(args.output_dir)
 
-    # create the output_dir
-    os.makedirs(output_dir, exist_ok=True)
+    assert os.path.exists(args.unreal_engine_dir)
 
     if sys.platform == "win32":
         platform          = "Windows"
@@ -54,15 +51,30 @@ if __name__ == '__main__':
     # once we know the platform, set our cooked dir
     unreal_project_cooked_dir = os.path.realpath(os.path.join(unreal_project_dir, "Saved", "Cooked", platform + "NoEditor"))
 
-    if args.create_symlinks:
+    # We do not want to use os.path.realpath(...) here, because that will resolve to the directory inside the user's Perforce workspace.
+    # Instead, we want this path to refer to the symlinked version inside the user's unreal project directory.
+    unreal_project_content_shared_dir = os.path.join(unreal_project_content_dir, "Shared")
+    unreal_project_content_scenes_dir = os.path.join(unreal_project_content_dir, "Scenes")
+
+    # scenario wherein we do not want to create symlinks
+    if args.skip_create_symlinks:
+        assert args.scene_ids is not None   # user should input the scene id
+        assert os.path.exists(unreal_project_content_shared_dir)    # shared dir should already exist
+        assert os.path.exists(unreal_project_content_scenes_dir)    # scenes dir should already exist
+
+        # check if the required scene content directory is in project's content directory
+        scene_ids = [ os.path.basename(x) for x in os.listdir(unreal_project_content_scenes_dir) ]
+        assert "starter_content_0000" in scene_ids
+        scene_ids.remove("starter_content_0000")
+        assert len(scene_ids) == 1      # there should only be one other scene, other than starter_content_0000
+        assert args.scene_ids in scene_ids
+
+    # scenario wherein we want to create symlinks
+    if not args.skip_create_symlinks:
         assert os.path.exists(args.perforce_content_dir)
 
         perforce_content_shared_dir = os.path.realpath(os.path.join(args.perforce_content_dir, "Shared"))
         perforce_content_scenes_dir = os.path.realpath(os.path.join(args.perforce_content_dir, "Scenes"))
-
-        # We do not want to use os.path.realpath(...) here, because that will resolve to the directory inside the user's Perforce workspace.
-        # Instead, we want this path to refer to the symlinked version inside the user's unreal project directory.
-        unreal_project_content_shared_dir = os.path.join(unreal_project_content_dir, "Shared")
 
         if spear.path_exists(unreal_project_content_shared_dir):
             print(f"[SPEAR | build_pak_files.py] File or directory or symlink exists, removing: {unreal_project_content_shared_dir}")
@@ -80,13 +92,23 @@ if __name__ == '__main__':
 
         assert len(scene_ids) > 0
 
-        for scene_id in scene_ids:
+    for scene_id in scene_ids:
 
+        pak_dirs = [
+            os.path.realpath(os.path.join(unreal_project_cooked_dir, "Engine", "Content")),
+            os.path.realpath(os.path.join(unreal_project_cooked_dir, "SpearSim", "Content", "Shared")),
+            os.path.realpath(os.path.join(unreal_project_cooked_dir, "SpearSim", "Content", "Scenes", scene_id)),
+        ]
+
+        txt_file = os.path.realpath(os.path.join(output_dir, scene_id + "-" + args.version_tag + "-" + platform + ".txt"))
+        pak_file = os.path.realpath(os.path.join(output_dir, scene_id + "-" + args.version_tag + "-" + platform + ".pak"))
+
+        # We do not want to use os.path.realpath(...) here, because that will resolve to the directory inside the user's Perforce workspace.
+        # Instead, we want this path to refer to the symlinked version inside the user's unreal project directory.
+        unreal_project_content_scene_dir = os.path.join(unreal_project_content_dir, "Scenes", scene_id)
+
+        if not args.skip_create_symlinks:
             perforce_content_scene_dir = os.path.realpath(os.path.join(perforce_content_scenes_dir, scene_id))
-
-            # We do not want to use os.path.realpath(...) here, because that will resolve to the directory inside the user's Perforce workspace.
-            # Instead, we want this path to refer to the symlinked version inside the user's unreal project directory.
-            unreal_project_content_scene_dir = os.path.join(unreal_project_content_dir, "Scenes", scene_id)
 
             if spear.path_exists(unreal_project_content_scene_dir):
                 print(f"[SPEAR | build_pak_files.py] File or directory or symlink exists, removing: {unreal_project_content_scene_dir}")
@@ -95,66 +117,6 @@ if __name__ == '__main__':
             print(f"[SPEAR | build_pak_files.py] Creating symlink: {unreal_project_content_scene_dir} -> {perforce_content_scene_dir}")
             os.symlink(perforce_content_scene_dir, unreal_project_content_scene_dir)
 
-            # see https://docs.unrealengine.com/4.26/en-US/SharingAndReleasing/Deployment/Cooking for more information on these parameters
-            cmd = [
-                unreal_editor_bin,
-                uproject,
-                "-run=Cook",
-                "-targetplatform=" + platform + "NoEditor",
-                "-fileopenlog",
-                "-ddc=InstalledDerivedDataBackendGraph",
-                "-unversioned",
-                "-stdout",
-                "-fullstdoutlogoutput",
-                "-crashforuat",
-                "-unattended",
-                "-nologtimes",
-                "-utf8output"
-            ]
-            print(f"[SPEAR | build_pak_files.py] Executing: {' '.join(cmd)}")
-            subprocess.run(cmd, check=True)
-
-            pak_dirs = [
-                os.path.realpath(os.path.join(unreal_project_cooked_dir, "Engine", "Content")),
-                os.path.realpath(os.path.join(unreal_project_cooked_dir, "SpearSim", "Content", "Shared")),
-                os.path.realpath(os.path.join(unreal_project_cooked_dir, "SpearSim", "Content", "Scenes", scene_id)),
-            ]
-
-            txt_file = os.path.realpath(os.path.join(output_dir, scene_id + "-" + args.version_tag + "-" + platform + ".txt"))
-            pak_file = os.path.realpath(os.path.join(output_dir, scene_id + "-" + args.version_tag + "-" + platform + ".pak"))
-
-            for i, pak_dir in enumerate(pak_dirs):
-                with open(txt_file, mode="w" if i==0 else "a") as f:
-                    for content_file in glob.glob(os.path.realpath(os.path.join(pak_dir, "**", "*.*")), recursive=True):
-                        assert content_file.startswith(unreal_project_cooked_dir)
-                        content_file = content_file.replace('\\', "/")
-                        mount_file = posixpath.join("..", "..", ".." + content_file.split(platform + "NoEditor")[1])
-                        f.write(f'"{content_file}" "{mount_file}" "" \n')
-
-            # construct command to generate the final pak file
-            cmd = [
-                unreal_pak_bin,
-                pak_file,
-                "-create=" + txt_file,
-                "-platform=" + platform,
-                "-multiprocess",
-                "-compress"
-            ]
-            print(f"[SPEAR | build_pak_files.py] Executing: {' '.join(cmd)}")
-            subprocess.run(cmd, check=True)
-
-            assert os.path.exists(pak_file)
-            print(f"[SPEAR | build_pak_files.py] Successfully built {pak_file}")
-
-            print(f"[SPEAR | build_pak_files.py] Removing symlink: {unreal_project_content_scene_dir}")
-            spear.remove_path(unreal_project_content_scene_dir)
-
-        print(f"[SPEAR | build_pak_files.py] Removing symlink: {unreal_project_content_shared_dir}")
-        spear.remove_path(unreal_project_content_shared_dir)
-
-        print("[SPEAR | build_pak_files.py] Done.")
-    # build pak file from uncooked contents in SpearSim project
-    else:
         # see https://docs.unrealengine.com/4.26/en-US/SharingAndReleasing/Deployment/Cooking for more information on these parameters
         cmd = [
             unreal_editor_bin,
@@ -174,13 +136,8 @@ if __name__ == '__main__':
         print(f"[SPEAR | build_pak_files.py] Executing: {' '.join(cmd)}")
         subprocess.run(cmd, check=True)
 
-        pak_dirs = [
-            os.path.realpath(os.path.join(unreal_project_cooked_dir, "Engine", "Content")),
-            os.path.realpath(os.path.join(unreal_project_cooked_dir, "SpearSim", "Content"))
-        ]
-
-        txt_file = os.path.realpath(os.path.join(output_dir, "SpearSim-" + args.version_tag + "-" + platform + ".txt"))
-        pak_file = os.path.realpath(os.path.join(output_dir, "SpearSim-" + args.version_tag + "-" + platform + ".pak"))
+        # create the output_dir
+        os.makedirs(output_dir, exist_ok=True)
 
         for i, pak_dir in enumerate(pak_dirs):
             with open(txt_file, mode="w" if i==0 else "a") as f:
@@ -204,3 +161,13 @@ if __name__ == '__main__':
 
         assert os.path.exists(pak_file)
         print(f"[SPEAR | build_pak_files.py] Successfully built {pak_file}")
+
+        if not args.skip_create_symlinks:
+            print(f"[SPEAR | build_pak_files.py] Removing symlink: {unreal_project_content_scene_dir}")
+            spear.remove_path(unreal_project_content_scene_dir)
+
+    if not args.skip_create_symlinks:
+        print(f"[SPEAR | build_pak_files.py] Removing symlink: {unreal_project_content_shared_dir}")
+        spear.remove_path(unreal_project_content_shared_dir)
+
+    print("[SPEAR | build_pak_files.py] Done.")

--- a/tools/build_pak_files.py
+++ b/tools/build_pak_files.py
@@ -23,12 +23,12 @@ if __name__ == '__main__':
     parser.add_argument("--scene_ids")
     args = parser.parse_args()
 
-    unreal_project_dir          = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "cpp", "unreal_projects", "SpearSim"))
-    uproject                    = os.path.realpath(os.path.join(unreal_project_dir, "SpearSim.uproject"))
-    unreal_project_content_dir  = os.path.realpath(os.path.join(unreal_project_dir, "Content"))
-    output_dir                  = os.path.realpath(args.output_dir)
-
     assert os.path.exists(args.unreal_engine_dir)
+
+    unreal_project_dir         = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "cpp", "unreal_projects", "SpearSim"))
+    uproject                   = os.path.realpath(os.path.join(unreal_project_dir, "SpearSim.uproject"))
+    unreal_project_content_dir = os.path.realpath(os.path.join(unreal_project_dir, "Content"))
+    output_dir                 = os.path.realpath(args.output_dir)
 
     if sys.platform == "win32":
         platform          = "Windows"
@@ -51,30 +51,32 @@ if __name__ == '__main__':
     # once we know the platform, set our cooked dir
     unreal_project_cooked_dir = os.path.realpath(os.path.join(unreal_project_dir, "Saved", "Cooked", platform + "NoEditor"))
 
-    # We do not want to use os.path.realpath(...) here, because that will resolve to the directory inside the user's Perforce workspace.
-    # Instead, we want this path to refer to the symlinked version inside the user's unreal project directory.
-    unreal_project_content_shared_dir = os.path.join(unreal_project_content_dir, "Shared")
-    unreal_project_content_scenes_dir = os.path.join(unreal_project_content_dir, "Scenes")
-
-    # scenario wherein we do not want to create symlinks
+    # We use different strategies for setting scene_ids, depending on if we're creating symlinks or not.
+    # If we're not creating symlinks, then the user must specify args.scene_ids. If we are creating
+    # symlinks, then we get a list of candidate scene_ids from Perforce and optionally filter.
     if args.skip_create_symlinks:
-        assert args.scene_ids is not None   # user should input the scene id
-        assert os.path.exists(unreal_project_content_shared_dir)    # shared dir should already exist
-        assert os.path.exists(unreal_project_content_scenes_dir)    # scenes dir should already exist
-
-        # check if the required scene content directory is in project's content directory
-        scene_ids = [ os.path.basename(x) for x in os.listdir(unreal_project_content_scenes_dir) ]
-        assert "starter_content_0000" in scene_ids
-        scene_ids.remove("starter_content_0000")
-        assert len(scene_ids) == 1      # apart from starter_content_0000, there should only be one other scene.
-        assert args.scene_ids in scene_ids
-
-    # scenario wherein we want to create symlinks
-    if not args.skip_create_symlinks:
+        assert args.scene_ids is not None
+        scene_ids = [args.scene_ids]
+    else:
         assert os.path.exists(args.perforce_content_dir)
-
-        perforce_content_shared_dir = os.path.realpath(os.path.join(args.perforce_content_dir, "Shared"))
         perforce_content_scenes_dir = os.path.realpath(os.path.join(args.perforce_content_dir, "Scenes"))
+        assert os.path.exists(perforce_content_scenes_dir)
+
+        ignore_names = [".DS_STORE"]
+        scene_ids = [ os.path.basename(x) for x in os.listdir(perforce_content_scenes_dir) if x not in ignore_names ]
+        assert len(scene_ids) > 0
+        if args.scene_ids is not None:
+            scene_ids = [ s for s in scene_ids if fnmatch.fnmatch(s, args.scene_ids) ]
+        assert len(scene_ids) > 0
+
+    # Create a symlink to the Shared directory
+    if not args.skip_create_symlinks:
+        perforce_content_shared_dir = os.path.realpath(os.path.join(args.perforce_content_dir, "Shared"))
+        assert os.path.exists(perforce_content_shared_dir)
+
+        # We do not want to use os.path.realpath(...) here, because that will resolve to the directory inside the user's Perforce workspace.
+        # Instead, we want this path to refer to the symlinked version inside the user's unreal project directory.
+        unreal_project_content_shared_dir = os.path.join(unreal_project_content_dir, "Shared")
 
         if spear.path_exists(unreal_project_content_shared_dir):
             print(f"[SPEAR | build_pak_files.py] File or directory or symlink exists, removing: {unreal_project_content_shared_dir}")
@@ -83,14 +85,10 @@ if __name__ == '__main__':
         print(f"[SPEAR | build_pak_files.py] Creating symlink: {unreal_project_content_shared_dir} -> {perforce_content_shared_dir}")
         os.symlink(perforce_content_shared_dir, unreal_project_content_shared_dir)
 
-        assert os.path.exists(perforce_content_scenes_dir)
-        scene_ids = [ os.path.basename(x) for x in os.listdir(perforce_content_scenes_dir) ]
-        assert len(scene_ids) > 0
-
-        if args.scene_ids is not None:
-            scene_ids = [ s for s in scene_ids if fnmatch.fnmatch(s, args.scene_ids) ]
-
-        assert len(scene_ids) > 0
+    # We do not want to use os.path.realpath(...) here, because that will resolve to the directory inside the user's Perforce workspace.
+    # Instead, we want this path to refer to the symlinked version inside the user's unreal project directory.
+    unreal_project_content_scenes_dir = os.path.join(unreal_project_content_dir, "Scenes")
+    assert os.path.exists(unreal_project_content_scenes_dir)
 
     for scene_id in scene_ids:
 
@@ -117,10 +115,10 @@ if __name__ == '__main__':
             print(f"[SPEAR | build_pak_files.py] Creating symlink: {unreal_project_content_scene_dir} -> {perforce_content_scene_dir}")
             os.symlink(perforce_content_scene_dir, unreal_project_content_scene_dir)
 
-            # Apart from starter_content_0000, there should only be one other scene.
-            project_scene_ids = [ os.path.basename(x) for x in os.listdir(unreal_project_content_scenes_dir) ]
-            assert "starter_content_0000" in project_scene_ids
-            assert len(project_scene_ids) == 2
+        # Now that we have created a symlink, our Unreal project should contain exactly two scenes: starter_content_0000 and scene_id
+        ignore_names = [".DS_STORE"]
+        unreal_project_scenes = { os.path.basename(x) for x in os.listdir(unreal_project_content_scenes_dir) if x not in ignore_names }
+        assert unreal_project_scenes == {"starter_content_0000", scene_id}
 
         # see https://docs.unrealengine.com/4.26/en-US/SharingAndReleasing/Deployment/Cooking for more information on these parameters
         cmd = [

--- a/tools/build_pak_files.py
+++ b/tools/build_pak_files.py
@@ -66,7 +66,7 @@ if __name__ == '__main__':
         scene_ids = [ os.path.basename(x) for x in os.listdir(unreal_project_content_scenes_dir) ]
         assert "starter_content_0000" in scene_ids
         scene_ids.remove("starter_content_0000")
-        assert len(scene_ids) == 1      # there should only be one other scene, other than starter_content_0000
+        assert len(scene_ids) == 1      # apart from starter_content_0000, there should only be one other scene.
         assert args.scene_ids in scene_ids
 
     # scenario wherein we want to create symlinks
@@ -116,6 +116,11 @@ if __name__ == '__main__':
 
             print(f"[SPEAR | build_pak_files.py] Creating symlink: {unreal_project_content_scene_dir} -> {perforce_content_scene_dir}")
             os.symlink(perforce_content_scene_dir, unreal_project_content_scene_dir)
+
+            # Apart from starter_content_0000, there should only be one other scene.
+            project_scene_ids = [ os.path.basename(x) for x in os.listdir(unreal_project_content_scenes_dir) ]
+            assert "starter_content_0000" in project_scene_ids
+            assert len(project_scene_ids) == 2
 
         # see https://docs.unrealengine.com/4.26/en-US/SharingAndReleasing/Deployment/Cooking for more information on these parameters
         cmd = [


### PR DESCRIPTION
- Modified `build_pak_files.py` to support the scenario wherein users can build pak files from existing content in SpearSim project.
- Setting `r.ReflectionCaptureResolution=1024`, caused issues with building pak files for `warehouse_0000` scene on Linux due to the very high `BuildData.uasset` file size. We decided to go with resolution as `128` (default set in UE).