### PR TITLE
fix UE 5.2 build issue related to symbolic links

### DIFF
--- a/cpp/unreal_plugins/CoreUtils/Source/CoreUtils/CoreUtils.Build.cs
+++ b/cpp/unreal_plugins/CoreUtils/Source/CoreUtils/CoreUtils.Build.cs
@@ -10,6 +10,8 @@ public class CoreUtils : ModuleRules
 {
     public CoreUtils(ReadOnlyTargetRules Target) : base(Target)
     {
+        Console.WriteLine("[SPEAR | CoreUtils.Build.cs] CoreUtils::CoreUtils");
+
         // Disable precompiled headers (in our code but not Unreal code) for faster builds,
         // easier debugging of compile errors, and strict enforcement of include-what-you-use.
         PCHUsage = ModuleRules.PCHUsageMode.Default;
@@ -24,29 +26,54 @@ public class CoreUtils : ModuleRules
         // everywhere.
         bEnableExceptions = true;
 
-        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine" });
+        PublicDependencyModuleNames.AddRange(new string[] {"Core", "CoreUObject", "Engine"});
         PrivateDependencyModuleNames.AddRange(new string[] {});
+
+        // TODO: This code needs to be wrapped in an #ifdef block because the function Directory.ResolveLinkTarget(...)
+        // is not defined for the older C# standard library that ships with UE 4.26. Once we are ready to migrate to UE
+        // 5.2, we can remove the #ifdef.
+
+        #if UE_52
+            // Resolve the top-level module directory and the ThirdParty directory, taking care to follow symlinks.
+            // The top-level module directory can be a symlink or not, and the ThirdParty directory can be a symlink
+            // or not. This is required to work around a bug that was introduced in UE 5.2.
+            string topLevelModuleDir = Path.GetFullPath(Path.Combine(ModuleDirectory, "..", ".."));
+            FileSystemInfo topLevelModuleDirInfo = Directory.ResolveLinkTarget(topLevelModuleDir, true);
+            topLevelModuleDir = (topLevelModuleDirInfo != null) ? topLevelModuleDirInfo.FullName : topLevelModuleDir;
+            Console.WriteLine("[SPEAR | CoreUtils.Build.cs] Resolved top-level module directory: " + topLevelModuleDir);
+
+            string thirdPartyDir = Path.GetFullPath(Path.Combine(topLevelModuleDir, "ThirdParty"));
+            FileSystemInfo thirdPartyDirInfo = Directory.ResolveLinkTarget(thirdPartyDir, true);
+            thirdPartyDir = (thirdPartyDirInfo != null) ? thirdPartyDirInfo.FullName : thirdPartyDir;
+            Console.WriteLine("[SPEAR | CoreUtils.Build.cs] Resolved third-party directory: " + thirdPartyDir);
+        #else
+            string topLevelModuleDir = Path.GetFullPath(Path.Combine(ModuleDirectory, "..", ".."));
+            Console.WriteLine("[SPEAR | CoreUtils.Build.cs] Resolved top-level module directory: " + topLevelModuleDir);
+
+            string thirdPartyDir = Path.GetFullPath(Path.Combine(topLevelModuleDir, "ThirdParty"));
+            Console.WriteLine("[SPEAR | CoreUtils.Build.cs] Resolved third-party directory: " + thirdPartyDir);
+        #endif
 
         //
         // Boost
         //
 
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost"));
+        PublicIncludePaths.Add(Path.GetFullPath(Path.Combine(thirdPartyDir, "boost")));
 
         //
         // rpclib
         //
 
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "rpclib", "include"));
+        PublicIncludePaths.Add(Path.GetFullPath(Path.Combine(thirdPartyDir, "rpclib", "include")));
 
         if (Target.Platform == UnrealTargetPlatform.Win64) {
-            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "rpclib", "BUILD", "Win64", "Release", "rpc.lib"));
+            PublicAdditionalLibraries.Add(Path.GetFullPath(Path.Combine(thirdPartyDir, "rpclib", "BUILD", "Win64", "Release", "rpc.lib")));
         } else if (Target.Platform == UnrealTargetPlatform.Mac) {
-            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "rpclib", "BUILD", "Mac", "librpc.a"));
+            PublicAdditionalLibraries.Add(Path.GetFullPath(Path.Combine(thirdPartyDir, "rpclib", "BUILD", "Mac", "librpc.a")));
         } else if (Target.Platform == UnrealTargetPlatform.Linux) {
-            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "rpclib", "BUILD", "Linux", "librpc.a"));
+            PublicAdditionalLibraries.Add(Path.GetFullPath(Path.Combine(thirdPartyDir, "rpclib", "BUILD", "Linux", "librpc.a")));
         } else {
-            throw new Exception("[SPEAR | CoreUtils.Build.cs] Target.Platform == " + Target.Platform);
+            throw new Exception("[SPEAR | CoreUtils.Build.cs] Unexpected target platform: " + Target.Platform);
         }
 
         //
@@ -54,17 +81,17 @@ public class CoreUtils : ModuleRules
         //
 
         bEnableExceptions = true;
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "yaml-cpp", "include"));
+        PublicIncludePaths.Add(Path.GetFullPath(Path.Combine(thirdPartyDir, "yaml-cpp", "include")));
 
         if (Target.Platform == UnrealTargetPlatform.Win64) {
             PublicDefinitions.Add("YAML_CPP_STATIC_DEFINE");
-            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "yaml-cpp", "BUILD", "Win64", "Release", "yaml-cpp.lib"));
+            PublicAdditionalLibraries.Add(Path.GetFullPath(Path.Combine(thirdPartyDir, "yaml-cpp", "BUILD", "Win64", "Release", "yaml-cpp.lib")));
         } else if (Target.Platform == UnrealTargetPlatform.Mac) {
-            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "yaml-cpp", "BUILD", "Mac", "libyaml-cpp.a"));
+            PublicAdditionalLibraries.Add(Path.GetFullPath(Path.Combine(thirdPartyDir, "yaml-cpp", "BUILD", "Mac", "libyaml-cpp.a")));
         } else if (Target.Platform == UnrealTargetPlatform.Linux) {
-            PublicAdditionalLibraries.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "yaml-cpp", "BUILD", "Linux", "libyaml-cpp.a"));
+            PublicAdditionalLibraries.Add(Path.GetFullPath(Path.Combine(thirdPartyDir, "yaml-cpp", "BUILD", "Linux", "libyaml-cpp.a")));
         } else {
-            throw new Exception("[SPEAR | CoreUtils.Build.cs] Unexpected: Target.Platform == " + Target.Platform);
+            throw new Exception("[SPEAR | CoreUtils.Build.cs] Unexpected target platform: " + Target.Platform);
         }
     }
 }

--- a/cpp/unreal_plugins/OpenBot/Source/OpenBot/OpenBot.Build.cs
+++ b/cpp/unreal_plugins/OpenBot/Source/OpenBot/OpenBot.Build.cs
@@ -10,6 +10,8 @@ public class OpenBot : ModuleRules
 {
     public OpenBot(ReadOnlyTargetRules Target) : base(Target)
     {
+        Console.WriteLine("[SPEAR | OpenBot.Build.cs] OpenBot::OpenBot");
+
         // Disable precompiled headers (in our code but not Unreal code) for faster builds,
         // easier debugging of compile errors, and strict enforcement of include-what-you-use.
         PCHUsage = ModuleRules.PCHUsageMode.Default;
@@ -24,21 +26,46 @@ public class OpenBot : ModuleRules
         // everywhere.
         bEnableExceptions = true;
 
-        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "CoreUtils", "Engine", "PhysX", "PhysXVehicleLib", "PhysXVehicles" });
+        PublicDependencyModuleNames.AddRange(new string[] {"Core", "CoreUObject", "CoreUtils", "Engine", "PhysX", "PhysXVehicleLib", "PhysXVehicles"});
         PrivateDependencyModuleNames.AddRange(new string[] {});
+
+        // TODO: This code needs to be wrapped in an #ifdef block because the function Directory.ResolveLinkTarget(...)
+        // is not defined for the older C# standard library that ships with UE 4.26. Once we are ready to migrate to UE
+        // 5.2, we can remove the #ifdef.
+
+        #if UE_52
+            // Resolve the top-level module directory and the ThirdParty directory, taking care to follow symlinks.
+            // The top-level module directory can be a symlink or not, and the ThirdParty directory can be a symlink
+            // or not. This is required to work around a bug that was introduced in UE 5.2.
+            string topLevelModuleDir = Path.GetFullPath(Path.Combine(ModuleDirectory, "..", ".."));
+            FileSystemInfo topLevelModuleDirInfo = Directory.ResolveLinkTarget(topLevelModuleDir, true);
+            topLevelModuleDir = (topLevelModuleDirInfo != null) ? topLevelModuleDirInfo.FullName : topLevelModuleDir;
+            Console.WriteLine("[SPEAR | OpenBot.Build.cs] Resolved top-level module directory: " + topLevelModuleDir);
+
+            string thirdPartyDir = Path.GetFullPath(Path.Combine(topLevelModuleDir, "ThirdParty"));
+            FileSystemInfo thirdPartyDirInfo = Directory.ResolveLinkTarget(thirdPartyDir, true);
+            thirdPartyDir = (thirdPartyDirInfo != null) ? thirdPartyDirInfo.FullName : thirdPartyDir;
+            Console.WriteLine("[SPEAR | OpenBot.Build.cs] Resolved third-party directory: " + thirdPartyDir);
+        #else
+            string topLevelModuleDir = Path.GetFullPath(Path.Combine(ModuleDirectory, "..", ".."));
+            Console.WriteLine("[SPEAR | OpenBot.Build.cs] Resolved top-level module directory: " + topLevelModuleDir);
+
+            string thirdPartyDir = Path.GetFullPath(Path.Combine(topLevelModuleDir, "ThirdParty"));
+            Console.WriteLine("[SPEAR | OpenBot.Build.cs] Resolved third-party directory: " + thirdPartyDir);
+        #endif
 
         //
         // Eigen
         //
 
         if (Target.Platform == UnrealTargetPlatform.Win64) {
-            PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "libeigen", "BUILD", "Win64", "include", "eigen3"));
+            PublicIncludePaths.Add(Path.GetFullPath(Path.Combine(thirdPartyDir, "libeigen", "BUILD", "Win64", "include", "eigen3")));
         } else if (Target.Platform == UnrealTargetPlatform.Mac) {
-            PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "libeigen", "BUILD", "Mac", "include", "eigen3"));
+            PublicIncludePaths.Add(Path.GetFullPath(Path.Combine(thirdPartyDir, "libeigen", "BUILD", "Mac", "include", "eigen3")));
         } else if (Target.Platform == UnrealTargetPlatform.Linux) {
-            PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "libeigen", "BUILD", "Linux", "include", "eigen3"));
+            PublicIncludePaths.Add(Path.GetFullPath(Path.Combine(thirdPartyDir, "libeigen", "BUILD", "Linux", "include", "eigen3")));
         } else {
-            throw new Exception("[SPEAR | OpenBot.Build.cs] Unexpected: Target.Platform == " + Target.Platform);
+            throw new Exception("[SPEAR | OpenBot.Build.cs] Unexpected target platform: " + Target.Platform);
         }
     }
 }

--- a/cpp/unreal_plugins/SimulationController/Source/SimulationController/SimulationController.Build.cs
+++ b/cpp/unreal_plugins/SimulationController/Source/SimulationController/SimulationController.Build.cs
@@ -10,6 +10,8 @@ public class SimulationController : ModuleRules
 {
     public SimulationController(ReadOnlyTargetRules Target) : base(Target)
     {
+        Console.WriteLine("[SPEAR | SimulationController.Build.cs] SimulationController::SimulationController");
+
         // Disable precompiled headers (in our code but not Unreal code) for faster builds,
         // easier debugging of compile errors, and strict enforcement of include-what-you-use.
         PCHUsage = ModuleRules.PCHUsageMode.Default;
@@ -20,7 +22,8 @@ public class SimulationController : ModuleRules
         OptimizeCode = ModuleRules.CodeOptimization.InShippingBuildsOnly;
 
         PublicDependencyModuleNames.AddRange(new string[] {
-            "Core", "CoreUObject", "CoreUtils", "Engine", "NavigationSystem", "OpenBot", "RenderCore", "RHI", "UrdfBot" });
+            "Core", "CoreUObject", "CoreUtils", "Engine", "NavigationSystem", "OpenBot", "RenderCore", "RHI", "UrdfBot"
+        });
         PrivateDependencyModuleNames.AddRange(new string[] {});
 
         // Our ASSERT macro throws exceptions, and so does our templated function Config::get(...),
@@ -33,10 +36,35 @@ public class SimulationController : ModuleRules
          // Required for boost::interprocess
         bEnableUndefinedIdentifierWarnings = false;
 
+        // TODO: This code needs to be wrapped in an #ifdef block because the function Directory.ResolveLinkTarget(...)
+        // is not defined for the older C# standard library that ships with UE 4.26. Once we are ready to migrate to UE
+        // 5.2, we can remove the #ifdef.
+
+        #if UE_52
+            // Resolve the top-level module directory and the ThirdParty directory, taking care to follow symlinks.
+            // The top-level module directory can be a symlink or not, and the ThirdParty directory can be a symlink
+            // or not. This is required to work around a bug that was introduced in UE 5.2.
+            string topLevelModuleDir = Path.GetFullPath(Path.Combine(ModuleDirectory, "..", ".."));
+            FileSystemInfo topLevelModuleDirInfo = Directory.ResolveLinkTarget(topLevelModuleDir, true);
+            topLevelModuleDir = (topLevelModuleDirInfo != null) ? topLevelModuleDirInfo.FullName : topLevelModuleDir;
+            Console.WriteLine("[SPEAR | SimulationController.Build.cs] Resolved top-level module directory: " + topLevelModuleDir);
+
+            string thirdPartyDir = Path.GetFullPath(Path.Combine(topLevelModuleDir, "ThirdParty"));
+            FileSystemInfo thirdPartyDirInfo = Directory.ResolveLinkTarget(thirdPartyDir, true);
+            thirdPartyDir = (thirdPartyDirInfo != null) ? thirdPartyDirInfo.FullName : thirdPartyDir;
+            Console.WriteLine("[SPEAR | SimulationController.Build.cs] Resolved third-party directory: " + thirdPartyDir);
+        #else
+            string topLevelModuleDir = Path.GetFullPath(Path.Combine(ModuleDirectory, "..", ".."));
+            Console.WriteLine("[SPEAR | SimulationController.Build.cs] Resolved top-level module directory: " + topLevelModuleDir);
+
+            string thirdPartyDir = Path.GetFullPath(Path.Combine(topLevelModuleDir, "ThirdParty"));
+            Console.WriteLine("[SPEAR | SimulationController.Build.cs] Resolved third-party directory: " + thirdPartyDir);
+        #endif
+
         //
         // Boost
         //
 
-        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "boost"));
+        PublicIncludePaths.Add(Path.GetFullPath(Path.Combine(thirdPartyDir, "boost")));
     }
 }

--- a/cpp/unreal_plugins/UrdfBot/Source/UrdfBot/UrdfBot.Build.cs
+++ b/cpp/unreal_plugins/UrdfBot/Source/UrdfBot/UrdfBot.Build.cs
@@ -10,6 +10,8 @@ public class UrdfBot : ModuleRules
 {
     public UrdfBot(ReadOnlyTargetRules Target) : base(Target)
     {
+        Console.WriteLine("[SPEAR | UrdfBot.Build.cs] UrdfBot::UrdfBot");
+
         // Disable precompiled headers (in our code but not Unreal code) for faster builds,
         // easier debugging of compile errors, and strict enforcement of include-what-you-use.
         PCHUsage = ModuleRules.PCHUsageMode.Default;
@@ -24,21 +26,46 @@ public class UrdfBot : ModuleRules
         // everywhere.
         bEnableExceptions = true;
 
-        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "CoreUtils", "Engine", "InputCore", "Slate", "XmlParser" });
+        PublicDependencyModuleNames.AddRange(new string[] {"Core", "CoreUObject", "CoreUtils", "Engine", "InputCore", "Slate", "XmlParser"});
         PrivateDependencyModuleNames.AddRange(new string[] {});
+
+        // TODO: This code needs to be wrapped in an #ifdef block because the function Directory.ResolveLinkTarget(...)
+        // is not defined for the older C# standard library that ships with UE 4.26. Once we are ready to migrate to UE
+        // 5.2, we can remove the #ifdef.
+
+        #if UE_52
+            // Resolve the top-level module directory and the ThirdParty directory, taking care to follow symlinks.
+            // The top-level module directory can be a symlink or not, and the ThirdParty directory can be a symlink
+            // or not. This is required to work around a bug that was introduced in UE 5.2.
+            string topLevelModuleDir = Path.GetFullPath(Path.Combine(ModuleDirectory, "..", ".."));
+            FileSystemInfo topLevelModuleDirInfo = Directory.ResolveLinkTarget(topLevelModuleDir, true);
+            topLevelModuleDir = (topLevelModuleDirInfo != null) ? topLevelModuleDirInfo.FullName : topLevelModuleDir;
+            Console.WriteLine("[SPEAR | UrdfBot.Build.cs] Resolved top-level module directory: " + topLevelModuleDir);
+
+            string thirdPartyDir = Path.GetFullPath(Path.Combine(topLevelModuleDir, "ThirdParty"));
+            FileSystemInfo thirdPartyDirInfo = Directory.ResolveLinkTarget(thirdPartyDir, true);
+            thirdPartyDir = (thirdPartyDirInfo != null) ? thirdPartyDirInfo.FullName : thirdPartyDir;
+            Console.WriteLine("[SPEAR | UrdfBot.Build.cs] Resolved third-party directory: " + thirdPartyDir);
+        #else
+            string topLevelModuleDir = Path.GetFullPath(Path.Combine(ModuleDirectory, "..", ".."));
+            Console.WriteLine("[SPEAR | UrdfBot.Build.cs] Resolved top-level module directory: " + topLevelModuleDir);
+
+            string thirdPartyDir = Path.GetFullPath(Path.Combine(topLevelModuleDir, "ThirdParty"));
+            Console.WriteLine("[SPEAR | UrdfBot.Build.cs] Resolved third-party directory: " + thirdPartyDir);
+        #endif
 
         //
         // Eigen
         //
 
         if (Target.Platform == UnrealTargetPlatform.Win64) {
-            PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "libeigen", "BUILD", "Win64", "include", "eigen3"));
+            PublicIncludePaths.Add(Path.GetFullPath(Path.Combine(thirdPartyDir, "libeigen", "BUILD", "Win64", "include", "eigen3")));
         } else if (Target.Platform == UnrealTargetPlatform.Mac) {
-            PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "libeigen", "BUILD", "Mac", "include", "eigen3"));
+            PublicIncludePaths.Add(Path.GetFullPath(Path.Combine(thirdPartyDir, "libeigen", "BUILD", "Mac", "include", "eigen3")));
         } else if (Target.Platform == UnrealTargetPlatform.Linux) {
-            PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "libeigen", "BUILD", "Linux", "include", "eigen3"));
+            PublicIncludePaths.Add(Path.GetFullPath(Path.Combine(thirdPartyDir, "libeigen", "BUILD", "Linux", "include", "eigen3")));
         } else {
-            throw new Exception("[SPEAR | UrdfBot.Build.cs] Unexpected: Target.Platform == " + Target.Platform);
+            throw new Exception("[SPEAR | UrdfBot.Build.cs] Unexpected target platform: " + Target.Platform);
         }
     }
 }

--- a/cpp/unreal_projects/SpearSim/Source/SpearSim.Target.cs
+++ b/cpp/unreal_projects/SpearSim/Source/SpearSim.Target.cs
@@ -10,9 +10,11 @@ public class SpearSimTarget : TargetRules
 {
     public SpearSimTarget(TargetInfo Target) : base(Target)
     {
+        Console.WriteLine("[SPEAR | SpearSim.Target.cs] SpearSimTarget::SpearSimTarget");
+
         Type = TargetType.Game;
         DefaultBuildSettings = BuildSettingsVersion.V2;
-        ExtraModuleNames.AddRange(new string[] { "SpearSim" });
+        ExtraModuleNames.AddRange(new string[] {"SpearSim"});
 
         if (Target.Platform == UnrealTargetPlatform.Win64) {
 
@@ -45,10 +47,10 @@ public class SpearSimTarget : TargetRules
         }
 
         // We can't throw an exception here, because when we invoke GenerateProjectFiles.bat or GenerateProjectFiles.sh (packaged with
-        // the Unreal Engine), instances of this class gets created with Target.Platform set to many different platforms (e.g., iOS, tvOS,
+        // the Unreal Engine), instances of this class get created with Target.Platform set to many different platforms (e.g., iOS, tvOS,
         // Win32, etc).
         // } else {
-        //    throw new Exception("[SPEAR | SpearSim.Target.cs] Target.Platform == " + Target.Platform);            
+        //    throw new Exception("[SPEAR | SpearSim.Target.cs] Unexpected target platform: " + Target.Platform);            
         // }
     }
 }

--- a/cpp/unreal_projects/SpearSim/Source/SpearSim.Target.cs
+++ b/cpp/unreal_projects/SpearSim/Source/SpearSim.Target.cs
@@ -28,22 +28,42 @@ public class SpearSimTarget : TargetRules
             bOverrideBuildEnvironment = true;
             AdditionalCompilerArguments = "";
 
-            AdditionalCompilerArguments +=
-                " -ffile-prefix-map=" +
-                Path.Combine(ProjectFile.Directory.FullName, "Plugins") + "=" +
-                Path.GetFullPath(Path.Combine(ProjectFile.Directory.FullName, "..", "..", "unreal_plugins"));
+            string arg = "";
+            Console.WriteLine("[SPEAR | SpearSimEditor.Target.cs] Additional compiler arguments:");
 
-            AdditionalCompilerArguments +=
-                " -ffile-prefix-map=" +
-                Path.Combine(ProjectFile.Directory.FullName, "ThirdParty") + "=" +
-                Path.GetFullPath(Path.Combine(ProjectFile.Directory.FullName, "..", "..", "..", "third_party"));
+            foreach (string pluginDir in Directory.GetDirectories(Path.Combine(ProjectFile.Directory.FullName, "Plugins"))) {
+                string plugin = (new DirectoryInfo(pluginDir)).Name;
 
-            foreach (string plugin in Directory.GetDirectories(Path.Combine(ProjectFile.Directory.FullName, "Plugins"))) {
-                AdditionalCompilerArguments +=
+                // Do the most specific substitution first. If we do a less specific substitution first, then we might not ever perform the
+                // more specific substitution, depending on how the -ffile-prefix-map argument is handled by the compiler.                
+
+                // Old: path/to/spear/cpp/unreal_projects/SpearSim/Plugins/MyPlugin/ThirdParty
+                // New: path/to/spear/third_party
+                arg =
                     " -ffile-prefix-map=" +
-                    Path.Combine(plugin, "ThirdParty") + "=" +
+                    Path.GetFullPath(Path.Combine(pluginDir, "ThirdParty")) + "=" +
                     Path.GetFullPath(Path.Combine(ProjectFile.Directory.FullName, "..", "..", "..", "third_party"));
+                AdditionalCompilerArguments += arg;
+                Console.WriteLine("[SPEAR | SpearSimEditor.Target.cs]     " + arg);
+
+                // Old: path/to/spear/cpp/unreal_projects/SpearSim/Plugins/MyPlugin
+                // New: path/to/spear/cpp/unreal_plugins/MyPlugin
+                arg =
+                    " -ffile-prefix-map=" +
+                    Path.GetFullPath(Path.Combine(pluginDir)) + "=" +
+                    Path.GetFullPath(Path.Combine(ProjectFile.Directory.FullName, "..", "..", "unreal_plugins", plugin));
+                AdditionalCompilerArguments += arg;
+                Console.WriteLine("[SPEAR | SpearSimEditor.Target.cs]     " + arg);
             }
+
+            // Old: path/to/spear/cpp/unreal_projects/SpearSim/ThirdParty
+            // New: path/to/spear/cpp/unreal_plugins/ThirdParty
+            arg =
+                " -ffile-prefix-map=" +
+                Path.GetFullPath(Path.Combine(ProjectFile.Directory.FullName, "ThirdParty")) + "=" +
+                Path.GetFullPath(Path.Combine(ProjectFile.Directory.FullName, "..", "..", "..", "third_party"));
+            AdditionalCompilerArguments += arg;
+            Console.WriteLine("[SPEAR | SpearSimEditor.Target.cs]     " + arg);
         }
 
         // We can't throw an exception here, because when we invoke GenerateProjectFiles.bat or GenerateProjectFiles.sh (packaged with

--- a/cpp/unreal_projects/SpearSim/Source/SpearSim.Target.cs
+++ b/cpp/unreal_projects/SpearSim/Source/SpearSim.Target.cs
@@ -57,7 +57,7 @@ public class SpearSimTarget : TargetRules
             }
 
             // Old: path/to/spear/cpp/unreal_projects/SpearSim/ThirdParty
-            // New: path/to/spear/cpp/unreal_plugins/ThirdParty
+            // New: path/to/spear/third_party
             arg =
                 " -ffile-prefix-map=" +
                 Path.GetFullPath(Path.Combine(ProjectFile.Directory.FullName, "ThirdParty")) + "=" +

--- a/cpp/unreal_projects/SpearSim/Source/SpearSim.Target.cs
+++ b/cpp/unreal_projects/SpearSim/Source/SpearSim.Target.cs
@@ -29,7 +29,7 @@ public class SpearSimTarget : TargetRules
             AdditionalCompilerArguments = "";
 
             string arg = "";
-            Console.WriteLine("[SPEAR | SpearSimEditor.Target.cs] Additional compiler arguments:");
+            Console.WriteLine("[SPEAR | SpearSim.Target.cs] Additional compiler arguments:");
 
             foreach (string pluginDir in Directory.GetDirectories(Path.Combine(ProjectFile.Directory.FullName, "Plugins"))) {
                 string plugin = (new DirectoryInfo(pluginDir)).Name;
@@ -44,7 +44,7 @@ public class SpearSimTarget : TargetRules
                     Path.GetFullPath(Path.Combine(pluginDir, "ThirdParty")) + "=" +
                     Path.GetFullPath(Path.Combine(ProjectFile.Directory.FullName, "..", "..", "..", "third_party"));
                 AdditionalCompilerArguments += arg;
-                Console.WriteLine("[SPEAR | SpearSimEditor.Target.cs]     " + arg);
+                Console.WriteLine("[SPEAR | SpearSim.Target.cs]     " + arg);
 
                 // Old: path/to/spear/cpp/unreal_projects/SpearSim/Plugins/MyPlugin
                 // New: path/to/spear/cpp/unreal_plugins/MyPlugin
@@ -53,7 +53,7 @@ public class SpearSimTarget : TargetRules
                     Path.GetFullPath(Path.Combine(pluginDir)) + "=" +
                     Path.GetFullPath(Path.Combine(ProjectFile.Directory.FullName, "..", "..", "unreal_plugins", plugin));
                 AdditionalCompilerArguments += arg;
-                Console.WriteLine("[SPEAR | SpearSimEditor.Target.cs]     " + arg);
+                Console.WriteLine("[SPEAR | SpearSim.Target.cs]     " + arg);
             }
 
             // Old: path/to/spear/cpp/unreal_projects/SpearSim/ThirdParty
@@ -63,7 +63,7 @@ public class SpearSimTarget : TargetRules
                 Path.GetFullPath(Path.Combine(ProjectFile.Directory.FullName, "ThirdParty")) + "=" +
                 Path.GetFullPath(Path.Combine(ProjectFile.Directory.FullName, "..", "..", "..", "third_party"));
             AdditionalCompilerArguments += arg;
-            Console.WriteLine("[SPEAR | SpearSimEditor.Target.cs]     " + arg);
+            Console.WriteLine("[SPEAR | SpearSim.Target.cs]     " + arg);
         }
 
         // We can't throw an exception here, because when we invoke GenerateProjectFiles.bat or GenerateProjectFiles.sh (packaged with

--- a/cpp/unreal_projects/SpearSim/Source/SpearSim/SpearSim.Build.cs
+++ b/cpp/unreal_projects/SpearSim/Source/SpearSim/SpearSim.Build.cs
@@ -2,12 +2,15 @@
 // Copyright(c) 2022 Intel. Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 //
 
+using System;
 using UnrealBuildTool;
 
 public class SpearSim : ModuleRules
 {
     public SpearSim(ReadOnlyTargetRules Target) : base(Target)
     {
+        Console.WriteLine("[SPEAR | SpearSim.Build.cs] SpearSim::SpearSim");
+
         // Disable precompiled headers (in our code but not Unreal code) for faster builds,
         // easier debugging of compile errors, and strict enforcement of include-what-you-use.
         PCHUsage = ModuleRules.PCHUsageMode.Default;

--- a/cpp/unreal_projects/SpearSim/Source/SpearSimEditor.Target.cs
+++ b/cpp/unreal_projects/SpearSim/Source/SpearSimEditor.Target.cs
@@ -10,9 +10,11 @@ public class SpearSimEditorTarget : TargetRules
 {
     public SpearSimEditorTarget(TargetInfo Target) : base(Target)
     {
+        Console.WriteLine("[SPEAR | SpearSimEditor.Target.cs] SpearSimEditorTarget::SpearSimEditorTarget");
+
         Type = TargetType.Editor;
         DefaultBuildSettings = BuildSettingsVersion.V2;
-        ExtraModuleNames.AddRange(new string[] { "SpearSim" });
+        ExtraModuleNames.AddRange(new string[] {"SpearSim"});
 
         if (Target.Platform == UnrealTargetPlatform.Win64) {
 
@@ -44,7 +46,7 @@ public class SpearSimEditorTarget : TargetRules
             }
 
         } else {
-            throw new Exception("[SPEAR | SpearSimEditor.Target.cs] Target.Platform == " + Target.Platform);            
+            throw new Exception("[SPEAR | SpearSimEditor.Target.cs] Unexpected target platform: " + Target.Platform);            
         }
     }
 }

--- a/cpp/unreal_projects/SpearSim/Source/SpearSimEditor.Target.cs
+++ b/cpp/unreal_projects/SpearSim/Source/SpearSimEditor.Target.cs
@@ -28,22 +28,42 @@ public class SpearSimEditorTarget : TargetRules
             bOverrideBuildEnvironment = true;
             AdditionalCompilerArguments = "";
 
-            AdditionalCompilerArguments +=
-                " -ffile-prefix-map=" +
-                Path.Combine(ProjectFile.Directory.FullName, "Plugins") + "=" +
-                Path.GetFullPath(Path.Combine(ProjectFile.Directory.FullName, "..", "..", "unreal_plugins"));
+            string arg = "";
+            Console.WriteLine("[SPEAR | SpearSimEditor.Target.cs] Additional compiler arguments:");
 
-            AdditionalCompilerArguments +=
-                " -ffile-prefix-map=" +
-                Path.Combine(ProjectFile.Directory.FullName, "ThirdParty") + "=" +
-                Path.GetFullPath(Path.Combine(ProjectFile.Directory.FullName, "..", "..", "..", "third_party"));
+            foreach (string pluginDir in Directory.GetDirectories(Path.Combine(ProjectFile.Directory.FullName, "Plugins"))) {
+                string plugin = (new DirectoryInfo(pluginDir)).Name;
 
-            foreach (string plugin in Directory.GetDirectories(Path.Combine(ProjectFile.Directory.FullName, "Plugins"))) {
-                AdditionalCompilerArguments +=
+                // Do the most specific substitution first. If we do a less specific substitution first, then we might not ever perform the
+                // more specific substitution, depending on how the -ffile-prefix-map argument is handled by the compiler.                
+
+                // Old: path/to/spear/cpp/unreal_projects/SpearSim/Plugins/MyPlugin/ThirdParty
+                // New: path/to/spear/third_party
+                arg =
                     " -ffile-prefix-map=" +
-                    Path.Combine(plugin, "ThirdParty") + "=" +
+                    Path.GetFullPath(Path.Combine(pluginDir, "ThirdParty")) + "=" +
                     Path.GetFullPath(Path.Combine(ProjectFile.Directory.FullName, "..", "..", "..", "third_party"));
+                AdditionalCompilerArguments += arg;
+                Console.WriteLine("[SPEAR | SpearSimEditor.Target.cs]     " + arg);
+
+                // Old: path/to/spear/cpp/unreal_projects/SpearSim/Plugins/MyPlugin
+                // New: path/to/spear/cpp/unreal_plugins/MyPlugin
+                arg =
+                    " -ffile-prefix-map=" +
+                    Path.GetFullPath(Path.Combine(pluginDir)) + "=" +
+                    Path.GetFullPath(Path.Combine(ProjectFile.Directory.FullName, "..", "..", "unreal_plugins", plugin));
+                AdditionalCompilerArguments += arg;
+                Console.WriteLine("[SPEAR | SpearSimEditor.Target.cs]     " + arg);
             }
+
+            // Old: path/to/spear/cpp/unreal_projects/SpearSim/ThirdParty
+            // New: path/to/spear/cpp/unreal_plugins/ThirdParty
+            arg =
+                " -ffile-prefix-map=" +
+                Path.GetFullPath(Path.Combine(ProjectFile.Directory.FullName, "ThirdParty")) + "=" +
+                Path.GetFullPath(Path.Combine(ProjectFile.Directory.FullName, "..", "..", "..", "third_party"));
+            AdditionalCompilerArguments += arg;
+            Console.WriteLine("[SPEAR | SpearSimEditor.Target.cs]     " + arg);
 
         } else {
             throw new Exception("[SPEAR | SpearSimEditor.Target.cs] Unexpected target platform: " + Target.Platform);            

--- a/cpp/unreal_projects/SpearSim/Source/SpearSimEditor.Target.cs
+++ b/cpp/unreal_projects/SpearSim/Source/SpearSimEditor.Target.cs
@@ -57,7 +57,7 @@ public class SpearSimEditorTarget : TargetRules
             }
 
             // Old: path/to/spear/cpp/unreal_projects/SpearSim/ThirdParty
-            // New: path/to/spear/cpp/unreal_plugins/ThirdParty
+            // New: path/to/spear/third_party
             arg =
                 " -ffile-prefix-map=" +
                 Path.GetFullPath(Path.Combine(ProjectFile.Directory.FullName, "ThirdParty")) + "=" +


### PR DESCRIPTION
- fixes UE 5.2 build issue related to symbolic links
- safer handling of symbolic links in path remapping code (depending on how the -ffile-prefix-map argument is handled in clang, our previous code would potentially prevent stepping through third-party code, but this PR contains a fix)