### PR TITLE
update gym version to fix conflict with newer version of setuptools module

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     install_requires=[
         "coacd==1.0.0",
         "ffmpeg-python==0.2.0",
-        "gym==0.21.0",
+        "gym==0.23.0",
         "matplotlib==3.6.2",
         "mayavi==4.8.1",
         "mujoco==3.1.3",


### PR DESCRIPTION
`gym==0.21.0` has conflicts with `setuptools>65.5.0` (https://github.com/openai/gym/issues/3176). In order to resolve this issue,
1. the `setuptools` version must be downgraded, as the default version with python3.8 using conda is `69.5.1`. Also, the version of `wheels` must be downgraded to below `0.40.0` as noted [here](https://github.com/openai/gym/issues/3176#issuecomment-1553756866)
2. `gym` must be upgraded. Since, `gym` upgrade to `0.23.0` has no breaking API changes, 

I prefer this option 2 as it's better to upgrade modules rather than downgrading, and this option has the least code changes.